### PR TITLE
Add kernel build test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2306,10 +2306,10 @@ config_r:
 	/bin/bash script/Configure script/config.in
 
 
-.PHONY: modules clean
+.PHONY: modules clean test
 
 clean:
-	#$(MAKE) -C $(KSRC) M=$(shell pwd) clean
+        #$(MAKE) -C $(KSRC) M=$(shell pwd) clean
 	cd hal ; rm -fr */*/*/*.mod.c */*/*/*.mod */*/*/*.o */*/*/.*.cmd */*/*/*.ko
 	cd hal ; rm -fr */*/*.mod.c */*/*.mod */*/*.o */*/.*.cmd */*/*.ko
 	cd hal ; rm -fr */*.mod.c */*.mod */*.o */.*.cmd */*.ko
@@ -2323,4 +2323,10 @@ clean:
 	rm -fr *.mod.c *.mod *.o .*.cmd *.ko *~
 	rm -fr .tmp_versions
 endif
+
+test:
+	./tests/test_kernel_5.4.sh
+	./tests/test_kernel_5.10.sh
+	./tests/test_kernel_5.15.sh
+	./tests/test_kernel_6.1.sh
 

--- a/tests/test_kernel_5.10.sh
+++ b/tests/test_kernel_5.10.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+ARCH=arm64
+CROSS_COMPILE=aarch64-linux-gnu-
+KSRC=./linux-5.10
+if [ ! -d "$KSRC" ]; then
+    TARBALL="linux-5.10.tar.xz"
+    URL="https://cdn.kernel.org/pub/linux/kernel/v5.x/$TARBALL"
+    wget -O "$TARBALL" "$URL"
+    tar -xf "$TARBALL"
+    rm "$TARBALL"
+    (cd "$KSRC" && make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" defconfig && \
+     make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" modules_prepare)
+fi
+make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE KSRC=$KSRC modules

--- a/tests/test_kernel_5.15.sh
+++ b/tests/test_kernel_5.15.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+ARCH=arm64
+CROSS_COMPILE=aarch64-linux-gnu-
+KSRC=./linux-5.15
+if [ ! -d "$KSRC" ]; then
+    TARBALL="linux-5.15.tar.xz"
+    URL="https://cdn.kernel.org/pub/linux/kernel/v5.x/$TARBALL"
+    wget -O "$TARBALL" "$URL"
+    tar -xf "$TARBALL"
+    rm "$TARBALL"
+    (cd "$KSRC" && make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" defconfig && \
+     make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" modules_prepare)
+fi
+make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE KSRC=$KSRC modules

--- a/tests/test_kernel_5.4.sh
+++ b/tests/test_kernel_5.4.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+ARCH=arm64
+CROSS_COMPILE=aarch64-linux-gnu-
+KSRC=./linux-5.4
+if [ ! -d "$KSRC" ]; then
+    TARBALL="linux-5.4.tar.xz"
+    URL="https://cdn.kernel.org/pub/linux/kernel/v5.x/$TARBALL"
+    wget -O "$TARBALL" "$URL"
+    tar -xf "$TARBALL"
+    rm "$TARBALL"
+    (cd "$KSRC" && make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" defconfig && \
+     make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" modules_prepare)
+fi
+make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE KSRC=$KSRC modules

--- a/tests/test_kernel_6.1.sh
+++ b/tests/test_kernel_6.1.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+ARCH=arm64
+CROSS_COMPILE=aarch64-linux-gnu-
+KSRC=./linux-6.1
+if [ ! -d "$KSRC" ]; then
+    TARBALL="linux-6.1.tar.xz"
+    URL="https://cdn.kernel.org/pub/linux/kernel/v6.x/$TARBALL"
+    wget -O "$TARBALL" "$URL"
+    tar -xf "$TARBALL"
+    rm "$TARBALL"
+    (cd "$KSRC" && make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" defconfig && \
+     make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE HOSTCFLAGS="-fcommon" modules_prepare)
+fi
+make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE KSRC=$KSRC modules


### PR DESCRIPTION
## Summary
- add kernel module test scripts for versions 5.4, 5.10, 5.15 and 6.1
- provide `make test` target executing all scripts
- restore Makefile executable bit

## Testing
- `make test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3f3df988331b1362af55dcfff1d