### PR TITLE
Add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ as you can see in the various header files of the source code.
 
 ## Copyright
 The Realtek Corporation is the copyright holder of this software.
+
+## Testing
+
+See [TESTING.md](TESTING.md) for instructions on building the driver against a
+cross‑compiled Linux kernel. The required packages listed there must be
+installed before running `tests/test_kernel_5.4.sh`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,24 @@
+Testing Instructions
+====================
+
+Before running any of the kernel build tests, make sure the following packages are installed:
+
+- build-essential (includes `gcc` and `make`)
+- `flex`
+- `bison`
+- `bc`
+- `wget`
+- `tar`
+- `xz-utils`
+- the `aarch64-linux-gnu` cross‑compiler toolchain
+- any other dependencies required for building a Linux kernel (for example, `libssl-dev` and `libelf-dev`)
+
+These packages must be installed before running `tests/test_kernel_5.4.sh`.
+
+Once these packages are available, you can execute the test script for building against Linux 5.4:
+
+```sh
+$ ./tests/test_kernel_5.4.sh
+```
+
+The script downloads and prepares the Linux 5.4 sources if needed and then builds the driver modules using the AArch64 cross‑compiler.


### PR DESCRIPTION
## Summary
- document required packages in TESTING.md
- link to testing instructions from README

## Testing
- `bash tests/test_kernel_5.4.sh` *(fails: `flex` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d7c7fa888331bf8c0d0e3148c70d