### PR TITLE
Remove legacy 2.x kernel code

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -95,14 +95,6 @@
 	#define UINT u32
 	#define ULONG u32
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 19))
-typedef _Bool bool;
-
-enum {
-	false	= 0,
-	true	= 1
-};
-#endif
 
 	typedef void (*proc_t)(void *);
 

--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -116,9 +116,7 @@ void rtw_os_ndevs_unregister(struct dvobj_priv *dvobj);
 int rtw_os_ndevs_init(struct dvobj_priv *dvobj);
 void rtw_os_ndevs_deinit(struct dvobj_priv *dvobj);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
 u16 rtw_recv_select_queue(struct sk_buff *skb);
-#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35) */
 
 int rtw_ndev_notifier_register(void);
 void rtw_ndev_notifier_unregister(void);

--- a/include/usb_ops_linux.h
+++ b/include/usb_ops_linux.h
@@ -35,28 +35,10 @@
 
 #define RTW_USB_BULKOUT_TIMEOUT	5000/* ms */
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 5, 0)) || (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 18))
-#define _usbctrl_vendorreq_async_callback(urb, regs)	_usbctrl_vendorreq_async_callback(urb)
-#define usb_bulkout_zero_complete(purb, regs)	usb_bulkout_zero_complete(purb)
-#define usb_write_mem_complete(purb, regs)	usb_write_mem_complete(purb)
-#define usb_write_port_complete(purb, regs)	usb_write_port_complete(purb)
-#define usb_read_port_complete(purb, regs)	usb_read_port_complete(purb)
-#define usb_read_interrupt_complete(purb, regs)	usb_read_interrupt_complete(purb)
-#endif
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 12))
 #define rtw_usb_control_msg(dev, pipe, request, requesttype, value, index, data, size, timeout_ms) \
 	usb_control_msg((dev), (pipe), (request), (requesttype), (value), (index), (data), (size), (timeout_ms))
 #define rtw_usb_bulk_msg(usb_dev, pipe, data, len, actual_length, timeout_ms) \
 	usb_bulk_msg((usb_dev), (pipe), (data), (len), (actual_length), (timeout_ms))
-#else
-#define rtw_usb_control_msg(dev, pipe, request, requesttype, value, index, data, size, timeout_ms) \
-	usb_control_msg((dev), (pipe), (request), (requesttype), (value), (index), (data), (size), \
-		((timeout_ms) == 0) || ((timeout_ms) * HZ / 1000 > 0) ? ((timeout_ms) * HZ / 1000) : 1)
-#define rtw_usb_bulk_msg(usb_dev, pipe, data, len, actual_length, timeout_ms) \
-	usb_bulk_msg((usb_dev), (pipe), (data), (len), (actual_length), \
-		((timeout_ms) == 0) || ((timeout_ms) * HZ / 1000 > 0) ? ((timeout_ms) * HZ / 1000) : 1)
-#endif
 
 
 #ifdef CONFIG_USB_SUPPORT_ASYNC_VDN_REQ
@@ -92,7 +74,7 @@ u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem);
 void usb_recv_tasklet(void *priv);
 
 #ifdef CONFIG_USB_INTERRUPT_IN_PIPE
-void usb_read_interrupt_complete(struct urb *purb, struct pt_regs *regs);
+void usb_read_interrupt_complete(struct urb *purb);
 u32 usb_read_interrupt(struct intf_hdl *pintfhdl, u32 addr);
 #endif
 #endif

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -39,44 +39,17 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define proc_get_parent_data(inode) PDE((inode))->parent->data
 #endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24))
-#define get_proc_net proc_net
-#else
 #define get_proc_net init_net.proc_net
-#endif
 
 inline struct proc_dir_entry *rtw_proc_create_dir(const char *name, struct proc_dir_entry *parent, void *data)
 {
-	struct proc_dir_entry *entry;
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0))
-	entry = proc_mkdir_data(name, S_IRUGO | S_IXUGO, parent, data);
-#else
-	/* entry = proc_mkdir_mode(name, S_IRUGO|S_IXUGO, parent); */
-	entry = proc_mkdir(name, parent);
-	if (entry)
-		entry->data = data;
-#endif
-
-	return entry;
+        return proc_mkdir_data(name, S_IRUGO | S_IXUGO, parent, data);
 }
 
 inline struct proc_dir_entry *rtw_proc_create_entry(const char *name, struct proc_dir_entry *parent,
-	const struct file_operations *fops, void * data)
+        const struct file_operations *fops, void * data)
 {
-	struct proc_dir_entry *entry;
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26))
-	entry = proc_create_data(name,  S_IFREG | S_IRUGO | S_IWUGO, parent, fops, data);
-#else
-	entry = create_proc_entry(name, S_IFREG | S_IRUGO | S_IWUGO, parent);
-	if (entry) {
-		entry->data = data;
-		entry->proc_fops = fops;
-	}
-#endif
-
-	return entry;
+        return proc_create_data(name,  S_IFREG | S_IRUGO | S_IWUGO, parent, fops, data);
 }
 
 static int proc_get_dummy(struct seq_file *m, void *v)

--- a/os_dep/linux/usb_ops_linux.c
+++ b/os_dep/linux/usb_ops_linux.c
@@ -198,7 +198,7 @@ exit:
 }
 
 #ifdef CONFIG_USB_SUPPORT_ASYNC_VDN_REQ
-static void _usbctrl_vendorreq_async_callback(struct urb *urb, struct pt_regs *regs)
+static void _usbctrl_vendorreq_async_callback(struct urb *urb)
 {
 	if (urb) {
 		if (urb->context)
@@ -300,7 +300,7 @@ struct zero_bulkout_context {
 	void *padapter;
 };
 
-static void usb_bulkout_zero_complete(struct urb *purb, struct pt_regs *regs)
+static void usb_bulkout_zero_complete(struct urb *purb)
 {
 	struct zero_bulkout_context *pcontext = (struct zero_bulkout_context *)purb->context;
 
@@ -410,7 +410,7 @@ void usb_read_port_cancel(struct intf_hdl *pintfhdl)
 #endif
 }
 
-static void usb_write_port_complete(struct urb *purb, struct pt_regs *regs)
+static void usb_write_port_complete(struct urb *purb)
 {
 	_irqL irqL;
 	struct xmit_buf *pxmitbuf = (struct xmit_buf *)purb->context;
@@ -747,7 +747,7 @@ void usb_recv_tasklet(void *priv)
 	}
 }
 
-void usb_read_port_complete(struct urb *purb, struct pt_regs *regs)
+void usb_read_port_complete(struct urb *purb)
 {
 	struct recv_buf	*precvbuf = (struct recv_buf *)purb->context;
 	_adapter			*padapter = (_adapter *)precvbuf->adapter;
@@ -900,7 +900,7 @@ void usb_recv_tasklet(void *priv)
 	}
 }
 
-void usb_read_port_complete(struct urb *purb, struct pt_regs *regs)
+void usb_read_port_complete(struct urb *purb)
 {
 	struct recv_buf	*precvbuf = (struct recv_buf *)purb->context;
 	_adapter			*padapter = (_adapter *)precvbuf->adapter;
@@ -1057,7 +1057,7 @@ exit:
 #endif /* CONFIG_USE_USB_BUFFER_ALLOC_RX */
 
 #ifdef CONFIG_USB_INTERRUPT_IN_PIPE
-void usb_read_interrupt_complete(struct urb *purb, struct pt_regs *regs)
+void usb_read_interrupt_complete(struct urb *purb)
 {
 	int	err;
 	_adapter	*padapter = (_adapter *)purb->context;


### PR DESCRIPTION
## Summary
- drop compatibility code for old Linux 2.x kernels
- use modern kernel helpers unconditionally
- fix USB completion callbacks for modern kernel API

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc3fc6b88331975dd02b9410d667