### PR TITLE
Cleanup kernel compatibility

### DIFF
--- a/core/mesh/rtw_mesh_pathtbl.c
+++ b/core/mesh/rtw_mesh_pathtbl.c
@@ -18,28 +18,11 @@
 #include <drv_types.h>
 #include <linux/jhash.h>
 
-#ifdef PLATFORM_LINUX
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0))
 static void rtw_mpath_free_rcu(struct rtw_mesh_path *mpath)
 {
-	kfree_rcu(mpath, rcu);
-	rtw_mstat_update(MSTAT_TYPE_PHY, MSTAT_FREE, sizeof(struct rtw_mesh_path));
+        kfree_rcu(mpath, rcu);
+        rtw_mstat_update(MSTAT_TYPE_PHY, MSTAT_FREE, sizeof(struct rtw_mesh_path));
 }
-#else
-static void rtw_mpath_free_rcu_callback(rtw_rcu_head *head)
-{
-	struct rtw_mesh_path *mpath;
-
-	mpath = container_of(head, struct rtw_mesh_path, rcu);
-	rtw_mfree(mpath, sizeof(struct rtw_mesh_path));
-}
-
-static void rtw_mpath_free_rcu(struct rtw_mesh_path *mpath)
-{
-	call_rcu(&mpath->rcu, rtw_mpath_free_rcu_callback);
-}
-#endif
-#endif /* PLATFORM_LINUX */
 
 static void rtw_mesh_path_free_rcu(struct rtw_mesh_table *tbl, struct rtw_mesh_path *mpath);
 

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1768,7 +1768,7 @@ chbw_decision:
 	rtw_hal_set_mcc_setting_start_bss_network(padapter, chbw_allow);
 #endif
 
-#if defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
+#ifdef CONFIG_IOCTL_CFG80211
 	for (i = 0; i < pdvobj->iface_nums; i++) {
 		if (!(ifbmp_ch_changed & BIT(i)) || !pdvobj->padapters[i])
 			continue;
@@ -1790,7 +1790,7 @@ chbw_decision:
 				, ht_option);
 		}
 	}
-#endif /* defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */
+#endif /* CONFIG_IOCTL_CFG80211 */
 
 	if (DUMP_ADAPTERS_STATUS) {
 		RTW_INFO(FUNC_ADPT_FMT" done\n", FUNC_ADPT_ARG(padapter));

--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1419,11 +1419,7 @@ void rtw_btcoex_recvmsgbysocket(void *data)
 	}
 }
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
-	void rtw_btcoex_recvmsg_init(struct sock *sk_in, s32 bytes)
-#else
-	void rtw_btcoex_recvmsg_init(struct sock *sk_in)
-#endif
+void rtw_btcoex_recvmsg_init(struct sock *sk_in)
 {
 	struct bt_coex_info *pcoex_info = NULL;
 
@@ -1459,28 +1455,14 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 	iov.iov_len	 = msg_size;
 	udpmsg.msg_name	 = &pcoex_info->bt_sockaddr;
 	udpmsg.msg_namelen	= sizeof(struct sockaddr_in);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
-	/* referece:sock_xmit in kernel code
-	 * WRITE for sock_sendmsg, READ for sock_recvmsg
-	 * third parameter for msg_iovlen
-	 * last parameter for iov_len
-	 */
-	iov_iter_init(&udpmsg.msg_iter, WRITE, &iov, 1, msg_size);
-#else
-	udpmsg.msg_iov	 = &iov;
-	udpmsg.msg_iovlen	= 1;
-#endif
+iov_iter_init(&udpmsg.msg_iter, WRITE, &iov, 1, msg_size);
 	udpmsg.msg_control	= NULL;
 	udpmsg.msg_controllen = 0;
 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
-	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg);
-#else
-	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg, msg_size);
-#endif
+error = sock_sendmsg(pcoex_info->udpsock, &udpmsg);
 	set_fs(oldfs);
 	if (error < 0) {
 		RTW_INFO("Error when sendimg msg, error:%d\n", error);

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -16082,12 +16082,12 @@ void rtw_join_done_chk_ch(_adapter *adapter, int join_res)
 					rtw_start_bss_hdl_after_chbw_decided(iface);
 
 					if (MLME_IS_GO(iface) || MLME_IS_MESH(iface)) { /* pure AP is not needed*/
-						#if defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
+                                               #ifdef CONFIG_IOCTL_CFG80211
 						u8 ht_option = 0;
 
 						#ifdef CONFIG_80211N_HT
 						ht_option = mlme->htpriv.ht_option;
-						#endif
+                                               #endif
 
 						rtw_cfg80211_ch_switch_notify(iface
 							, mlmeext->cur_channel, mlmeext->cur_bwmode, mlmeext->cur_ch_offset
@@ -16296,7 +16296,7 @@ exit:
 		*bw = u_bw;
 		*offset = u_offset;
 
-#if defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
+#ifdef CONFIG_IOCTL_CFG80211
 		{
 			u8 ht_option = 0;
 

--- a/hal/hal_btcoex.c
+++ b/hal/hal_btcoex.c
@@ -2278,11 +2278,7 @@ static COL_H2C_STATUS halbtcoutsrc_send_h2c(PADAPTER Adapter, PCOL_H2C pcol_h2c,
 	COL_H2C_STATUS		h2c_status = COL_STATUS_C2H_OK;
 	u8				i;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0))
-	reinit_completion(&gl_coex_offload.c2h_event[pcol_h2c->req_num]);		/* set event to un signaled state */
-#else
-	INIT_COMPLETION(gl_coex_offload.c2h_event[pcol_h2c->req_num]);
-#endif
+reinit_completion(&gl_coex_offload.c2h_event[pcol_h2c->req_num]);
 
 	if (TRUE) {
 #if 0	/*(USE_HAL_MAC_API == 1) */

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -59,11 +59,7 @@
 	#include <linux/tqueue.h>
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0))
-	#include <uapi/linux/limits.h>
-#else
-	#include <linux/limits.h>
-#endif
+#include <uapi/linux/limits.h>
 
 #ifdef RTK_DMP_PLATFORM
 	#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 12))
@@ -259,13 +255,8 @@ __inline static _list *get_next(_list	*list)
 #define rtw_hlist_for_each_entry(pos, head, member) hlist_for_each_entry(pos, head, member)
 #define rtw_hlist_for_each_safe(pos, n, head) hlist_for_each_safe(pos, n, head)
 #define rtw_hlist_entry(ptr, type, member) hlist_entry(ptr, type, member)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0))
 #define rtw_hlist_for_each_entry_safe(pos, np, n, head, member) hlist_for_each_entry_safe(pos, n, head, member)
 #define rtw_hlist_for_each_entry_rcu(pos, node, head, member) hlist_for_each_entry_rcu(pos, head, member)
-#else
-#define rtw_hlist_for_each_entry_safe(pos, np, n, head, member) hlist_for_each_entry_safe(pos, np, n, head, member)
-#define rtw_hlist_for_each_entry_rcu(pos, node, head, member) hlist_for_each_entry_rcu(pos, node, head, member)
-#endif
 
 __inline static void _enter_critical(_lock *plock, _irqL *pirqL)
 {

--- a/include/rtw_android.h
+++ b/include/rtw_android.h
@@ -66,8 +66,8 @@ enum ANDROID_WIFI_CMD {
 	ANDROID_WIFI_CMD_HOSTAPD_SET_MACADDR_ACL,
 	ANDROID_WIFI_CMD_HOSTAPD_ACL_ADD_STA,
 	ANDROID_WIFI_CMD_HOSTAPD_ACL_REMOVE_STA,
-#if defined(CONFIG_GTK_OL) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 1, 0))
-	ANDROID_WIFI_CMD_GTK_REKEY_OFFLOAD,
+#ifdef CONFIG_GTK_OL
+       ANDROID_WIFI_CMD_GTK_REKEY_OFFLOAD,
 #endif /* CONFIG_GTK_OL */
 	ANDROID_WIFI_CMD_P2P_DISABLE,
 	ANDROID_WIFI_CMD_SET_AEK,
@@ -79,10 +79,10 @@ enum ANDROID_WIFI_CMD {
 int rtw_android_cmdstr_to_num(char *cmdstr);
 int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd);
 
-#if defined(CONFIG_PNO_SUPPORT) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0))
+#ifdef CONFIG_PNO_SUPPORT
 int rtw_android_pno_enable(struct net_device *net, int pno_enable);
 int rtw_android_cfg80211_pno_setup(struct net_device *net,
-		   struct cfg80211_ssid *ssid, int n_ssids, int interval);
+                   struct cfg80211_ssid *ssid, int n_ssids, int interval);
 #endif
 
 #if defined(RTW_ENABLE_WIFI_CONTROL_FUNC)
@@ -93,11 +93,7 @@ void *wl_android_prealloc(int section, unsigned long size);
 int wifi_get_irq_number(unsigned long *irq_flags_ptr);
 int wifi_set_power(int on, unsigned long msec);
 int wifi_get_mac_addr(unsigned char *buf);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0))
 void *wifi_get_country_code(char *ccode, u32 flags);
-#else /* Linux kernel < 3.18 */
-void *wifi_get_country_code(char *ccode);
-#endif /* Linux kernel < 3.18 */
 #else
 static inline int rtw_android_wifictrl_func_add(void)
 {

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -407,22 +407,9 @@ static void rtw_get_chbw_from_cfg80211_chan_def(struct cfg80211_chan_def *chdef,
 }
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
 bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
 {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
-	if ((!MLME_IS_AP(adapter))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0))
-		&& (!MLME_IS_ADHOC(adapter))
-		&& (!MLME_IS_ADHOC_MASTER(adapter))
-		&& (!MLME_IS_MESH(adapter))
-#elif defined(CONFIG_RTW_MESH)
-		&& (!MLME_IS_MESH(adapter))
-#endif
-		)
-		return 0;
-#endif
-	return 1;
+       return 1;
 }
 
 u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht)
@@ -430,38 +417,20 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	struct wiphy *wiphy = adapter_to_wiphy(adapter);
 	u8 ret = _SUCCESS;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	struct cfg80211_chan_def chdef;
+       struct cfg80211_chan_def chdef;
 
-	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
-		goto exit;
+       if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
+               goto exit;
 
-	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
-	if (ret != _SUCCESS)
-		goto exit;
+       ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
+       if (ret != _SUCCESS)
+               goto exit;
 
-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
-
-#else
-	int freq = rtw_ch2freq(ch);
-	enum nl80211_channel_type ctype;
-
-	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
-		goto exit;
-
-	if (!freq) {
-		ret = _FAIL;
-		goto exit;
-	}
-
-	ctype = rtw_chbw_to_nl80211_channel_type(ch, bw, offset, ht);
-	cfg80211_ch_switch_notify(adapter->pnetdev, freq, ctype);
-#endif
+       cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
 
 exit:
-	return ret;
+       return ret;
 }
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */
 
 void rtw_2g_channels_init(struct ieee80211_channel *channels)
 {

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -69,14 +69,7 @@
 	#error "RTW_DEDICATED_P2P_DEVICE can't be enabled when RTW_P2P_GROUP_INTERFACE is disabled\n"
 #endif
 
-#if defined(RTW_DEDICATED_P2P_DEVICE) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0))
-	#error "RTW_DEDICATED_P2P_DEVICE can't be enabled when kernel < 3.7.0\n"
-#endif
-
 #ifdef CONFIG_RTW_MESH
-	#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
-		#error "CONFIG_RTW_MESH can't be enabled when kernel < 3.10.0\n"
-	#endif
 #endif
 
 struct rtw_wdev_invit_info {
@@ -351,73 +344,26 @@ void rtw_cfg80211_init_rfkill(struct wiphy *wiphy);
 void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))  && !defined(COMPAT_KERNEL_RELEASE)
-#define rtw_cfg80211_rx_mgmt(wdev, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt(wdev_to_ndev(wdev), freq, buf, len, gfp)
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))
-#define rtw_cfg80211_rx_mgmt(wdev, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt(wdev_to_ndev(wdev), freq, sig_dbm, buf, len, gfp)
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 12, 0))
-#define rtw_cfg80211_rx_mgmt(wdev, freq, sig_dbm, buf, len, gfp) cfg80211_rx_mgmt(wdev, freq, sig_dbm, buf, len, gfp)
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3 , 18 , 0))
-#define rtw_cfg80211_rx_mgmt(wdev , freq , sig_dbm , buf , len , gfp) cfg80211_rx_mgmt(wdev , freq , sig_dbm , buf , len , 0 , gfp)
-#else
 #define rtw_cfg80211_rx_mgmt(wdev , freq , sig_dbm , buf , len , gfp) cfg80211_rx_mgmt(wdev , freq , sig_dbm , buf , len , 0)
-#endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))  && !defined(COMPAT_KERNEL_RELEASE)
-#define rtw_cfg80211_send_rx_assoc(adapter, bss, buf, len) cfg80211_send_rx_assoc((adapter)->pnetdev, buf, len)
-#else
 #define rtw_cfg80211_send_rx_assoc(adapter, bss, buf, len) cfg80211_send_rx_assoc((adapter)->pnetdev, bss, buf, len)
-#endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))
-#define rtw_cfg80211_mgmt_tx_status(wdev, cookie, buf, len, ack, gfp) cfg80211_mgmt_tx_status(wdev_to_ndev(wdev), cookie, buf, len, ack, gfp)
-#else
 #define rtw_cfg80211_mgmt_tx_status(wdev, cookie, buf, len, ack, gfp) cfg80211_mgmt_tx_status(wdev, cookie, buf, len, ack, gfp)
-#endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))
-#define rtw_cfg80211_ready_on_channel(wdev, cookie, chan, channel_type, duration, gfp)  cfg80211_ready_on_channel(wdev_to_ndev(wdev), cookie, chan, channel_type, duration, gfp)
-#define rtw_cfg80211_remain_on_channel_expired(wdev, cookie, chan, chan_type, gfp) cfg80211_remain_on_channel_expired(wdev_to_ndev(wdev), cookie, chan, chan_type, gfp)
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
-#define rtw_cfg80211_ready_on_channel(wdev, cookie, chan, channel_type, duration, gfp)  cfg80211_ready_on_channel(wdev, cookie, chan, channel_type, duration, gfp)
-#define rtw_cfg80211_remain_on_channel_expired(wdev, cookie, chan, chan_type, gfp) cfg80211_remain_on_channel_expired(wdev, cookie, chan, chan_type, gfp)
-#else
 #define rtw_cfg80211_ready_on_channel(wdev, cookie, chan, channel_type, duration, gfp)  cfg80211_ready_on_channel(wdev, cookie, chan, duration, gfp)
 #define rtw_cfg80211_remain_on_channel_expired(wdev, cookie, chan, chan_type, gfp) cfg80211_remain_on_channel_expired(wdev, cookie, chan, gfp)
-#endif
 
 #define rtw_cfg80211_connect_result(wdev, bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp) cfg80211_connect_result(wdev_to_ndev(wdev), bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp)
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0))
-#define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, gfp)
-#else
 #define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, locally_generated, gfp)
-#endif
 
 #ifdef CONFIG_RTW_80211R
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0))
 #define rtw_cfg80211_ft_event(adapter, parm)  cfg80211_ft_event((adapter)->pnetdev, parm)
-#else
-	#error "Cannot support FT for KERNEL_VERSION < 3.10\n"
-#endif
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0))
 #define rtw_cfg80211_notify_new_peer_candidate(wdev, addr, ie, ie_len, gfp) cfg80211_notify_new_peer_candidate(wdev_to_ndev(wdev), addr, ie, ie_len, gfp)
-#endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
 u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht);
-#endif
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0))
-#define NL80211_BAND_2GHZ IEEE80211_BAND_2GHZ
-#define NL80211_BAND_5GHZ IEEE80211_BAND_5GHZ
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
-#define NL80211_BAND_60GHZ IEEE80211_BAND_60GHZ
-#endif
-#define NUM_NL80211_BANDS IEEE80211_NUM_BANDS
-#endif
 
 #define rtw_band_to_nl80211_band(band) \
 	(band == BAND_ON_2_4G) ? NL80211_BAND_2GHZ : \

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1398,11 +1398,7 @@ static int rtw_ndev_notifier_call(struct notifier_block *nb, unsigned long state
 	if (ptr == NULL)
 		return NOTIFY_DONE;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0))
-	ndev = netdev_notifier_info_to_dev(ptr);
-#else
-	ndev = ptr;
-#endif
+       ndev = netdev_notifier_info_to_dev(ptr);
 
 	if (ndev == NULL)
 		return NOTIFY_DONE;
@@ -1681,8 +1677,8 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 		goto exit;
 	}
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && defined(CONFIG_PCI_HCI)
-	ndev->gro_flush_timeout = 100000;
+#ifdef CONFIG_PCI_HCI
+       ndev->gro_flush_timeout = 100000;
 #endif
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
@@ -3998,28 +3994,14 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 
 	msg.msg_name = &nladdr;
 	msg.msg_namelen = sizeof(nladdr);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
-	/* referece:sock_xmit in kernel code
-	 * WRITE for sock_sendmsg, READ for sock_recvmsg
-	 * third parameter for msg_iovlen
-	 * last parameter for iov_len
-	 */
-	iov_iter_init(&msg.msg_iter, WRITE, &iov, 1, sizeof(req));
-#else
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
-#endif
+       iov_iter_init(&msg.msg_iter, WRITE, &iov, 1, sizeof(req));
 	msg.msg_control = NULL;
 	msg.msg_controllen = 0;
 	msg.msg_flags = MSG_DONTWAIT;
 
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
-	err = sock_sendmsg(sock, &msg);
-#else
-	err = sock_sendmsg(sock, &msg, sizeof(req));
-#endif
+       err = sock_sendmsg(sock, &msg);
 	set_fs(oldfs);
 
 	if (err < 0)
@@ -4041,9 +4023,7 @@ restart:
 		iov.iov_base = pg;
 		iov.iov_len = PAGE_SIZE;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
-		iov_iter_init(&msg.msg_iter, READ, &iov, 1, PAGE_SIZE);
-#endif
+               iov_iter_init(&msg.msg_iter, READ, &iov, 1, PAGE_SIZE);
 
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
@@ -4113,23 +4093,14 @@ done:
 
 		msg.msg_name = &nladdr;
 		msg.msg_namelen = sizeof(nladdr);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
-		iov_iter_init(&msg.msg_iter, WRITE, &iov, 1, sizeof(req));
-#else
-		msg.msg_iov = &iov;
-		msg.msg_iovlen = 1;
-#endif
+               iov_iter_init(&msg.msg_iter, WRITE, &iov, 1, sizeof(req));
 		msg.msg_control = NULL;
 		msg.msg_controllen = 0;
 		msg.msg_flags = MSG_DONTWAIT;
 
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
-		err = sock_sendmsg(sock, &msg);
-#else
-		err = sock_sendmsg(sock, &msg, sizeof(req));
-#endif
+               err = sock_sendmsg(sock, &msg);
 		set_fs(oldfs);
 
 		if (err > 0)

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -383,16 +383,12 @@ int rtw_recv_napi_poll(struct napi_struct *napi, int budget)
 	struct recv_priv *precvpriv = &padapter->recvpriv;
 
 
-	work_done = napi_recv(padapter, budget);
-	if (work_done < budget) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && defined(CONFIG_PCI_HCI)
-		napi_complete_done(napi, work_done);
-#else
-		napi_complete(napi);
-#endif
-		if (!skb_queue_empty(&precvpriv->rx_napi_skb_queue))
-			napi_schedule(napi);
-	}
+       work_done = napi_recv(padapter, budget);
+       if (work_done < budget) {
+               napi_complete_done(napi, work_done);
+               if (!skb_queue_empty(&precvpriv->rx_napi_skb_queue))
+                       napi_schedule(napi);
+       }
 
 	return work_done;
 }

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -89,8 +89,8 @@ const char *android_wifi_cmd_str[ANDROID_WIFI_CMD_MAX] = {
 	"HOSTAPD_SET_MACADDR_ACL",
 	"HOSTAPD_ACL_ADD_STA",
 	"HOSTAPD_ACL_REMOVE_STA",
-#if defined(CONFIG_GTK_OL) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 1, 0))
-	"GTK_REKEY_OFFLOAD",
+#ifdef CONFIG_GTK_OL
+       "GTK_REKEY_OFFLOAD",
 #endif /* CONFIG_GTK_OL */
 /*	Private command for	P2P disable*/
 	"P2P_DISABLE",
@@ -308,10 +308,8 @@ int rtw_android_cfg80211_pno_setup(struct net_device *net,
 		memcpy(pno_ssids_local[index].SSID, ssids[index].ssid,
 		       ssids[index].ssid_len);
 	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
-	if(ssids)
-		rtw_mfree((u8 *)ssids, (n_ssids * sizeof(struct cfg80211_ssid)));
-#endif
+       if (ssids)
+               rtw_mfree((u8 *)ssids, (n_ssids * sizeof(struct cfg80211_ssid)));
 	pno_time = (interval / 1000);
 
 	RTW_INFO("%s: nssids: %d, pno_time=%d\n", __func__, nssid, pno_time);
@@ -519,7 +517,7 @@ int get_int_from_command(char *pcmd)
 	return rtw_atoi(pcmd + i) ;
 }
 
-#if defined(CONFIG_GTK_OL) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 1, 0))
+#ifdef CONFIG_GTK_OL
 int rtw_gtk_offload(struct net_device *net, u8 *cmd_ptr)
 {
 	int i;
@@ -915,11 +913,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		break;
 	}
 #endif /* CONFIG_RTW_MACADDR_ACL */
-#if defined(CONFIG_GTK_OL) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 1, 0))
-	case ANDROID_WIFI_CMD_GTK_REKEY_OFFLOAD:
-		rtw_gtk_offload(net, (u8 *)command);
-		break;
-#endif /* CONFIG_GTK_OL		 */
+#ifdef CONFIG_GTK_OL
+        case ANDROID_WIFI_CMD_GTK_REKEY_OFFLOAD:
+                rtw_gtk_offload(net, (u8 *)command);
+                break;
+#endif /* CONFIG_GTK_OL          */
 	case ANDROID_WIFI_CMD_P2P_DISABLE: {
 #ifdef CONFIG_P2P
 		rtw_p2p_enable(padapter, P2P_ROLE_DISABLE);
@@ -1071,21 +1069,13 @@ int wifi_get_mac_addr(unsigned char *buf)
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35)) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)) || defined(COMPAT_KERNEL_RELEASE)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0))
 void *wifi_get_country_code(char *ccode, u32 flags)
-#else /* Linux kernel < 3.18 */
-void *wifi_get_country_code(char *ccode)
-#endif /* Linux kernel < 3.18 */
 {
 	RTW_INFO("%s\n", __FUNCTION__);
 	if (!ccode)
 		return NULL;
 	if (wifi_control_data && wifi_control_data->get_country_code)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0))
-		return wifi_control_data->get_country_code(ccode, flags);
-#else /* Linux kernel < 3.18 */
-		return wifi_control_data->get_country_code(ccode);
-#endif /* Linux kernel < 3.18 */
+               return wifi_control_data->get_country_code(ccode, flags);
 	return NULL;
 }
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)) */

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -17,7 +17,6 @@
 
 #ifdef CONFIG_IOCTL_CFG80211
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) || defined(RTW_VENDOR_EXT_SUPPORT)
 
 /*
 #include <linux/kernel.h>
@@ -2051,6 +2050,5 @@ int rtw_cfgvendor_detach(struct wiphy *wiphy)
 
 	return 0;
 }
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) || defined(RTW_VENDOR_EXT_SUPPORT) */
 
 #endif /* CONFIG_IOCTL_CFG80211 */

--- a/os_dep/linux/rtw_cfgvendor.h
+++ b/os_dep/linux/rtw_cfgvendor.h
@@ -609,16 +609,14 @@ typedef struct {
 #endif /* CONFIG_RTW_CFGVEDNOR_LLSTATS */
 
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) || defined(RTW_VENDOR_EXT_SUPPORT)
 extern int rtw_cfgvendor_attach(struct wiphy *wiphy);
 extern int rtw_cfgvendor_detach(struct wiphy *wiphy);
 extern int rtw_cfgvendor_send_async_event(struct wiphy *wiphy,
-	struct net_device *dev, int event_id, const void  *data, int len);
+        struct net_device *dev, int event_id, const void  *data, int len);
 #if defined(GSCAN_SUPPORT) && 0
 extern int rtw_cfgvendor_send_hotlist_event(struct wiphy *wiphy,
-	struct net_device *dev, void  *data, int len, rtw_vendor_event_t event);
+        struct net_device *dev, void  *data, int len, rtw_vendor_event_t event);
 #endif
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) || defined(RTW_VENDOR_EXT_SUPPORT) */
 
 #ifdef CONFIG_RTW_CFGVEDNOR_RSSIMONITOR
 void rtw_cfgvendor_rssi_monitor_evt(_adapter *padapter);

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -30,14 +30,7 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 
 #define RTW_PROC_NAME DRV_NAME
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0))
-#define file_inode(file) ((file)->f_dentry->d_inode)
-#endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
-#define PDE_DATA(inode) PDE((inode))->data
-#define proc_get_parent_data(inode) PDE((inode))->parent->data
-#endif
 
 #define get_proc_net init_net.proc_net
 

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -293,11 +293,7 @@ void rtw_regd_apply_flags(struct wiphy *wiphy)
 			&& rtw_odm_dfs_domain_unknown(dvobj)
 			#endif
 		) {
-			#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-			ch->flags = (IEEE80211_CHAN_NO_IBSS | IEEE80211_CHAN_PASSIVE_SCAN);
-			#else
-			ch->flags = IEEE80211_CHAN_NO_IR;
-			#endif
+                       ch->flags = IEEE80211_CHAN_NO_IR;
 		} else
 			ch->flags = 0;
 
@@ -307,12 +303,8 @@ void rtw_regd_apply_flags(struct wiphy *wiphy)
 			&& rtw_odm_dfs_domain_unknown(dvobj)
 			#endif
 		) {
-			ch->flags |= IEEE80211_CHAN_RADAR;
-			#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-			ch->flags |= (IEEE80211_CHAN_NO_IBSS | IEEE80211_CHAN_PASSIVE_SCAN);
-			#else
-			ch->flags |= IEEE80211_CHAN_NO_IR;
-			#endif
+                       ch->flags |= IEEE80211_CHAN_RADAR;
+                       ch->flags |= IEEE80211_CHAN_NO_IR;
 		}
 		#endif /* CONFIG_DFS */
 	}
@@ -355,33 +347,16 @@ static void rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *req
 	rtw_regd_apply_flags(wiphy);
 }
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0))
-static int rtw_reg_notifier_return(struct wiphy *wiphy, struct regulatory_request *request)
-{
-	rtw_reg_notifier(wiphy, request);
-	return 0;
-}
-#endif
 
 static void _rtw_regd_init_wiphy(struct rtw_regulatory *reg, struct wiphy *wiphy)
 {
 	const struct ieee80211_regdomain *regd;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0))
-	wiphy->reg_notifier = rtw_reg_notifier_return;
-#else
-	wiphy->reg_notifier = rtw_reg_notifier;
-#endif
+       wiphy->reg_notifier = rtw_reg_notifier;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-	wiphy->flags |= WIPHY_FLAG_CUSTOM_REGULATORY;
-	wiphy->flags &= ~WIPHY_FLAG_STRICT_REGULATORY;
-	wiphy->flags &= ~WIPHY_FLAG_DISABLE_BEACON_HINTS;
-#else
-	wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
-	wiphy->regulatory_flags &= ~REGULATORY_STRICT_REG;
-	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
-#endif
+       wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
+       wiphy->regulatory_flags &= ~REGULATORY_STRICT_REG;
+       wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 
 	regd = _rtw_regdomain_select(reg);
 	wiphy_apply_custom_regulatory(wiphy, regd);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2155,11 +2155,7 @@ static int isFileReadable(const char *path, u32 *sz)
 			ret = PTR_ERR(fp);
 
 		if (ret == 0 && sz) {
-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
-			*sz = i_size_read(fp->f_path.dentry->d_inode);
-			#else
-			*sz = i_size_read(fp->f_dentry->d_inode);
-			#endif
+                       *sz = i_size_read(fp->f_path.dentry->d_inode);
 		}
 
 		filp_close(fp, NULL);

--- a/platform/platform_aml_s905_sdio.c
+++ b/platform/platform_aml_s905_sdio.c
@@ -24,15 +24,7 @@
  */
 int platform_wifi_power_on(void)
 {
-	int ret = 0;
-
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-	ret = wifi_setup_dt();
-	if (ret) {
-		pr_err("%s: setup dt failed!!(%d)\n", __func__, ret);
-		return -1;
-	}
-#endif /* kernel < 3.14.0 */
+       int ret = 0;
 
 #if 0 /* Seems redundancy? Already done before insert driver */
 	pr_info("######%s:\n", __func__);
@@ -48,7 +40,5 @@ int platform_wifi_power_on(void)
 
 void platform_wifi_power_off(void)
 {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-	wifi_teardown_dt();
-#endif /* kernel < 3.14.0 */
+       /* no operation needed for modern kernels */
 }

--- a/platform/platform_aml_s905_sdio.h
+++ b/platform/platform_aml_s905_sdio.h
@@ -20,9 +20,4 @@
 extern void sdio_reinit(void);
 extern void extern_wifi_set_enable(int is_on);
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
-extern void wifi_teardown_dt(void);
-extern int wifi_setup_dt(void);
-#endif /* kernel < 3.14.0 */
-
 #endif /* __PLATFORM_AML_S905_SDIO_H__ */


### PR DESCRIPTION
## Summary
- remove conditional code for legacy kernel 3.x
- simplify 80211 band helpers
- drop obsolete platform hooks
- always use modern kernel APIs

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843301a0e508331ab0a8594a1b64c9d