### PR TITLE
Remove pre-4.0 kernel code

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -9532,14 +9532,6 @@ static void cfg80211_rtw_rfkill_poll(struct wiphy *wiphy)
 
 #if defined(CONFIG_RTW_HOSTAPD_ACS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 33))
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0))
-#define SURVEY_INFO_TIME			SURVEY_INFO_CHANNEL_TIME
-#define SURVEY_INFO_TIME_BUSY		SURVEY_INFO_CHANNEL_TIME_BUSY
-#define SURVEY_INFO_TIME_EXT_BUSY	SURVEY_INFO_CHANNEL_TIME_EXT_BUSY
-#define SURVEY_INFO_TIME_RX			SURVEY_INFO_CHANNEL_TIME_RX
-#define SURVEY_INFO_TIME_TX			SURVEY_INFO_CHANNEL_TIME_TX
-#endif
-
 #ifdef CONFIG_FIND_BEST_CHANNEL
 static void rtw_cfg80211_set_survey_info_with_find_best_channel(struct wiphy *wiphy
 	, struct net_device *netdev, int idx, struct survey_info *info)
@@ -9555,11 +9547,7 @@ static void rtw_cfg80211_set_survey_info_with_find_best_channel(struct wiphy *wi
 	u64 time = 100;		/*amount of time in ms the radio was turn on (on the channel)*/
 	u64 time_busy = 0;	/*amount of time the primary channel was sensed busy*/
 
-	info->filled  = SURVEY_INFO_NOISE_DBM
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-		| SURVEY_INFO_TIME | SURVEY_INFO_TIME_BUSY
-		#endif
-		;
+	info->filled  = SURVEY_INFO_NOISE_DBM | SURVEY_INFO_TIME | SURVEY_INFO_TIME_BUSY;
 
 	for (i = 0; i < ch_num; i++)
 		total_rx_cnt += ch_set[i].rx_count;
@@ -9567,15 +9555,8 @@ static void rtw_cfg80211_set_survey_info_with_find_best_channel(struct wiphy *wi
 	time_busy = ch_set[idx].rx_count * time / total_rx_cnt;
 	noise += ch_set[idx].rx_count * 50 / total_rx_cnt;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0))
-	info->channel_time = time;
-	info->channel_time_busy = time_busy;
-	#else
-	info->time = time;
-	info->time_busy = time_busy;
-	#endif
-#endif
+        info->time = time;
+        info->time_busy = time_busy;
 	info->noise = noise;
 
 	/* reset if final channel is got */
@@ -9597,25 +9578,14 @@ static void rtw_cfg80211_set_survey_info_with_clm(PADAPTER padapter, int idx, st
 	if ((idx < 0) || (pinfo == NULL))
 		return;
 
-	pinfo->filled  = SURVEY_INFO_NOISE_DBM
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-		| SURVEY_INFO_TIME | SURVEY_INFO_TIME_BUSY
-		#endif
-		;
+	pinfo->filled  = SURVEY_INFO_NOISE_DBM | SURVEY_INFO_TIME | SURVEY_INFO_TIME_BUSY;
 
 	time_busy = rtw_acs_get_clm_ratio_by_ch_idx(padapter, chan);
 	noise = rtw_noise_query_by_chan_idx(padapter, chan);
 	/* RTW_INFO("%s: ch-idx:%d time=%llu(ms), time_busy=%llu(ms), noise=%d(dbm)\n", __func__, idx, time, time_busy, noise); */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0))
-	pinfo->channel_time = time;
-	pinfo->channel_time_busy = time_busy;
-	#else
-	pinfo->time = time;
-	pinfo->time_busy = time_busy;
-	#endif
-#endif
+        pinfo->time = time;
+        pinfo->time_busy = time_busy;
 	pinfo->noise = noise;
 }
 #endif

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -21,11 +21,7 @@
 
 #if defined(RTW_ENABLE_WIFI_CONTROL_FUNC)
 #include <linux/platform_device.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-	#include <linux/wlan_plat.h>
-#else
-	#include <linux/wifi_tiwlan.h>
-#endif
+#include <linux/wlan_plat.h>
 #endif /* defined(RTW_ENABLE_WIFI_CONTROL_FUNC) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
@@ -1056,7 +1052,6 @@ int wifi_set_power(int on, unsigned long msec)
 	return 0;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
 int wifi_get_mac_addr(unsigned char *buf)
 {
 	RTW_INFO("%s\n", __FUNCTION__);
@@ -1066,9 +1061,7 @@ int wifi_get_mac_addr(unsigned char *buf)
 		return wifi_control_data->get_mac_addr(buf);
 	return -EOPNOTSUPP;
 }
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35)) */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)) || defined(COMPAT_KERNEL_RELEASE)
 void *wifi_get_country_code(char *ccode, u32 flags)
 {
 	RTW_INFO("%s\n", __FUNCTION__);
@@ -1078,7 +1071,6 @@ void *wifi_get_country_code(char *ccode, u32 flags)
                return wifi_control_data->get_country_code(ccode, flags);
 	return NULL;
 }
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)) */
 
 static int wifi_set_carddetect(int on)
 {
@@ -1240,19 +1232,14 @@ static void wifi_shutdown(struct platform_device *pdev)
 static int wifi_suspend(struct platform_device *pdev, pm_message_t state)
 {
 	RTW_INFO("##> %s\n", __FUNCTION__);
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 39)) && defined(OOB_INTR_ONLY)
-	bcmsdh_oob_intr_set(0);
-#endif
+
 	return 0;
 }
 
 static int wifi_resume(struct platform_device *pdev)
 {
 	RTW_INFO("##> %s\n", __FUNCTION__);
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 39)) && defined(OOB_INTR_ONLY)
-	if (dhd_os_check_if_up(bcmsdh_get_drvdata()))
-		bcmsdh_oob_intr_set(1);
-#endif
+
 	return 0;
 }
 

--- a/os_dep/linux/rtw_rhashtable.c
+++ b/os_dep/linux/rtw_rhashtable.c
@@ -43,29 +43,6 @@ int rtw_rhashtable_walk_enter(rtw_rhashtable *ht, rtw_rhashtable_iter *iter)
 }
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0))
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 25))
-static inline int is_vmalloc_addr(const void *x)
-{
-#ifdef CONFIG_MMU
-	unsigned long addr = (unsigned long)x;
-
-	return addr >= VMALLOC_START && addr < VMALLOC_END;
-#else
-	return 0;
-#endif
-}
-#endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 25)) */
-
-void kvfree(const void *addr)
-{
-	if (is_vmalloc_addr(addr))
-		vfree(addr);
-	else
-		kfree(addr);
-}
-#endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0)) */
-
 #include "rhashtable.c"
 
 #endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)) */

--- a/os_dep/linux/rtw_rhashtable.h
+++ b/os_dep/linux/rtw_rhashtable.h
@@ -24,9 +24,6 @@
 
 /* Use rhashtable from kernel 4.4 */
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0))
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0))
-#define NULLS_MARKER(value) (1UL | (((long)value) << 1))
-#endif
 #include "rhashtable.h"
 #endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)) */
 


### PR DESCRIPTION
## Summary
- drop legacy platform header selection in `rtw_android.c`
- remove obsolete version checks in cfg80211 helpers
- delete unused fallback rhashtable code
- define survey time fields unconditionally
- cleanup local rhashtable header

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_68434c002ec4833189aa6e3cc7b19a39