### PR TITLE
Fix build warnings on kernel 5.4

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -171,7 +171,7 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 	u8	bmatch = _FALSE;
 	u8	*pie = pnetwork->IEs;
 	u8	*p = NULL, *dst_ie = NULL, *premainder_ie = NULL, *pbackup_remainder_ie = NULL;
-	u32	i, offset, ielen, ie_offset, remainder_ielen = 0;
+	u32     i, offset, ielen = 0, ie_offset, remainder_ielen = 0;
 
 	for (i = sizeof(NDIS_802_11_FIXED_IEs); i < pnetwork->IELength;) {
 		pIE = (PNDIS_802_11_VARIABLE_IEs)(pnetwork->IEs + i);
@@ -234,7 +234,7 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 void rtw_remove_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index)
 {
 	u8 *p, *dst_ie = NULL, *premainder_ie = NULL, *pbackup_remainder_ie = NULL;
-	uint offset, ielen, ie_offset, remainder_ielen = 0;
+	uint offset, ielen = 0, ie_offset, remainder_ielen = 0;
 	u8	*pie = pnetwork->IEs;
 
 	p = rtw_get_ie(pie + _FIXED_IE_LENGTH_, index, &ielen, pnetwork->IELength - _FIXED_IE_LENGTH_);
@@ -4438,8 +4438,8 @@ static u8 rtw_ap_update_chbw_by_ifbmp(struct dvobj_priv *dvobj, u8 ifbmp
 	int i;
 
 	for (i = 0; i < dvobj->iface_nums; i++) {
-		if (!(ifbmp & BIT(i)) || !dvobj->padapters)
-			continue;
+               if (!(ifbmp & BIT(i)) || !dvobj->padapters[i])
+                       continue;
 
 		iface = dvobj->padapters[i];
 		mlmeext = &(iface->mlmeextpriv);
@@ -4458,8 +4458,8 @@ static u8 rtw_ap_update_chbw_by_ifbmp(struct dvobj_priv *dvobj, u8 ifbmp
 	}
 
 	for (i = 0; i < dvobj->iface_nums; i++) {
-		if (!(ifbmp & BIT(i)) || !dvobj->padapters)
-			continue;
+               if (!(ifbmp & BIT(i)) || !dvobj->padapters[i])
+                       continue;
 
 		iface = dvobj->padapters[i];
 		mlmeext = &(iface->mlmeextpriv);

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -256,9 +256,10 @@ void rtw_txpwr_init_regd(struct rf_ctl_t *rfctl)
 			, regd_str(regd)
 			, rfctl->regd_name ? "is used" : "not found"
 		);
-		if (rfctl->regd_name)
-			break;
-	default:
+               if (rfctl->regd_name)
+                       break;
+               /* fall through - use worldwide default */
+       default:
 		rfctl->regd_name = regd_str(TXPWR_LMT_WW);
 		RTW_PRINT("assign %s for default case\n", regd_str(TXPWR_LMT_WW));
 		break;
@@ -1340,10 +1341,10 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 	case WIFI_AUTH:
 		if (MLME_IS_AP(padapter) || MLME_IS_MESH(padapter))
 			ptable->func = &OnAuth;
-		else
-			ptable->func = &OnAuthClient;
-	/* pass through */
-	case WIFI_ASSOCREQ:
+               else
+                       ptable->func = &OnAuthClient;
+               /* fall through */
+       case WIFI_ASSOCREQ:
 	case WIFI_REASSOCREQ:
 		_mgt_dispatcher(padapter, ptable, precv_frame);
 		#ifdef CONFIG_HOSTAPD_MLME

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -2449,7 +2449,7 @@ u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
 			psd_data = rtw_GetPSDData(pAdapter, i - psd_pts);
 		else
 			psd_data = rtw_GetPSDData(pAdapter, i);
-		sprintf(data, "%s%x ", data, psd_data);
+               sprintf(data + strlen(data), "%x ", psd_data);
 		i++;
 	}
 

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -376,8 +376,8 @@ void rtw_mfree_stainfo(struct sta_info *psta);
 void rtw_mfree_stainfo(struct sta_info *psta)
 {
 
-	if (&psta->lock != NULL)
-		_rtw_spinlock_free(&psta->lock);
+       /* psta->lock is always valid, free it unconditionally */
+       _rtw_spinlock_free(&psta->lock);
 
 	_rtw_free_sta_xmit_priv_lock(&psta->sta_xmitpriv);
 	_rtw_free_sta_recv_priv_lock(&psta->sta_recvpriv);

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -3224,9 +3224,10 @@ void rtw_parse_sta_vendor_ie_8812(_adapter *adapter, struct sta_info *sta, u8 *t
 		goto exit;
 	else {
 		if(*(p+1) > 6 ) {
-			for(i=0; i<9;i++)
-				RTW_INFO("p[%d]=0x%x",i,*(p+i) );
-				RTW_INFO("\n");
+                       for (i = 0; i < 9; i++) {
+                               RTW_INFO("p[%d]=0x%x", i, *(p + i));
+                       }
+                       RTW_INFO("\n");
 			if(*(p+6) != 2)
 				goto exit;
 			

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -1074,11 +1074,11 @@ s32 c2h_handler(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
 		c2h_per_rate_rpt_hdl(adapter, payload, plen);
 		break;
 #endif
-	case C2H_EXTEND:
-		sub_id = payload[0];
-		/* no handle, goto default */
+       case C2H_EXTEND:
+               sub_id = payload[0];
+               /* fall through - handle by default */
 
-	default:
+       default:
 		if (phydm_c2H_content_parsing(adapter_to_phydm(adapter), id, plen, payload) != TRUE)
 			ret = _FAIL;
 		break;

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -2863,11 +2863,11 @@ void phydm_set_txagc_dbg(void *dm_void, char input[][16], u32 *_used,
 	char help[] = "-h";
 	u8 i = 0, input_idx = 0;
 
-	for (i = 0; i < 5; i++) {
-		if (input[i + 1]) {
-			PHYDM_SSCANF(input[i + 1], DCMD_HEX, &var1[i]);
-			input_idx++;
-		}
+       for (i = 0; i < 5; i++) {
+               if (input[i + 1][0]) {
+                       PHYDM_SSCANF(input[i + 1], DCMD_HEX, &var1[i]);
+                       input_idx++;
+               }
 	}
 
 	if ((strcmp(input[1], help) == 0)) {
@@ -2905,10 +2905,10 @@ void phydm_debug_trace(void *dm_void, char input[][16], u32 *_used,
 	u32 val[10] = {0};
 	u8 i;
 
-	for (i = 0; i < 5; i++) {
-		if (input[i + 1])
-			PHYDM_SSCANF(input[i + 1], DCMD_DECIMAL, &val[i]);
-	}
+       for (i = 0; i < 5; i++) {
+               if (input[i + 1][0])
+                       PHYDM_SSCANF(input[i + 1], DCMD_DECIMAL, &val[i]);
+       }
 	comp = dm->debug_components;
 	pre_debug_components = dm->debug_components;
 
@@ -3062,12 +3062,12 @@ void phydm_fw_debug_trace(void *dm_void, char input[][16], u32 *_used,
 	u32 pre_fw_debug_components = 0, one = 1;
 	u32 comp = 0;
 
-	for (i = 0; i < 5; i++) {
-		if (input[i + 1]) {
-			PHYDM_SSCANF(input[i + 1], DCMD_DECIMAL, &val[i]);
-			input_idx++;
-		}
-	}
+       for (i = 0; i < 5; i++) {
+               if (input[i + 1][0]) {
+                       PHYDM_SSCANF(input[i + 1], DCMD_DECIMAL, &val[i]);
+                       input_idx++;
+               }
+       }
 
 	if (input_idx == 0)
 		return;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2349,10 +2349,11 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 		break;
 
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
-	case NL80211_IFTYPE_P2P_CLIENT:
-		is_p2p = _TRUE;
-	#endif
-	case NL80211_IFTYPE_STATION:
+       case NL80211_IFTYPE_P2P_CLIENT:
+               is_p2p = _TRUE;
+               /* fall through */
+       #endif
+       case NL80211_IFTYPE_STATION:
 		networkType = Ndis802_11Infrastructure;
 
 		#ifdef CONFIG_P2P
@@ -2373,10 +2374,11 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 		break;
 
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
-	case NL80211_IFTYPE_P2P_GO:
-		is_p2p = _TRUE;
-	#endif
-	case NL80211_IFTYPE_AP:
+       case NL80211_IFTYPE_P2P_GO:
+               is_p2p = _TRUE;
+               /* fall through */
+       #endif
+       case NL80211_IFTYPE_AP:
 		networkType = Ndis802_11APMode;
 
 		#ifdef CONFIG_P2P
@@ -2880,8 +2882,8 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 #endif
 #ifdef CONFIG_P2P
 	if (pwdinfo->driver_interface == DRIVER_CFG80211) {
-		if (ssids->ssid != NULL
-			&& _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
+               if (ssids->ssid_len &&
+                       _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
 			&& rtw_get_p2p_ie((u8 *)request->ie, request->ie_len, NULL, NULL)
 		) {
 			if (rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -2988,8 +2990,8 @@ bypass_p2p_chk:
 
 #ifdef CONFIG_P2P
 	if (pwdinfo->driver_interface == DRIVER_CFG80211) {
-		if (ssids->ssid != NULL
-			&& _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
+               if (ssids->ssid_len &&
+                       _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
 			&& rtw_get_p2p_ie((u8 *)request->ie, request->ie_len, NULL, NULL)
 		) {
 			if (rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -570,15 +570,15 @@ int rtw_mp_txpower_index(struct net_device *dev,
 		sprintf(extra, "patha=%d", txpower_inx);
 		if (phal_data->rf_type > RF_1T2R) {
 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 1);
-			sprintf(extra, "%s,pathb=%d", extra, txpower_inx);
+               sprintf(extra + strlen(extra), ",pathb=%d", txpower_inx);
 		}
 		if (phal_data->rf_type > RF_2T4R) {
 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 2);
-			sprintf(extra, "%s,pathc=%d", extra, txpower_inx);
+               sprintf(extra + strlen(extra), ",pathc=%d", txpower_inx);
 		}
 		if (phal_data->rf_type > RF_3T4R) {
 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 3);
-			sprintf(extra, "%s,pathd=%d", extra, txpower_inx);
+               sprintf(extra + strlen(extra), ",pathd=%d", txpower_inx);
 		}
 	}
 	wrqu->length = strlen(extra);
@@ -2218,12 +2218,12 @@ int rtw_efuse_mask_file(struct net_device *dev,
 
 		 } while (count < 64);
 
-		for (i = 0; i < count; i++)
-			sprintf(extra, "%s:%02x", extra, maskfileBuffer[i]);
+               for (i = 0; i < count; i++)
+                       sprintf(extra + strlen(extra), ":%02x", maskfileBuffer[i]);
 
 		padapter->registrypriv.bFileMaskEfuse = _TRUE;
 
-		sprintf(extra, "%s\nLoad Efuse Mask data %d hex ok\n", extra, count);
+               sprintf(extra + strlen(extra), "\nLoad Efuse Mask data %d hex ok\n", count);
 		wrqu->data.length = strlen(extra);
 		return 0;
 	}


### PR DESCRIPTION
## Summary
- install build dependencies and run `tests/test_kernel_5.4.sh`
- fix various warnings triggered by gcc 5.4 build
  - remove useless NULL check in `rtw_mfree_stainfo`
  - correct adapter pointer checks in AP channel update path
  - add explicit fallthrough comments for gcc
  - avoid overlapping sprintf usage
  - check SSID length instead of address in cfg80211 code
  - use buffer appends when building strings
  - tighten input checks in phydm debug helpers
- rebuild module against Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh > /tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_684402aa2e2c8331b181ff6c5d9fb7d2