### PR TITLE
Remove kernel <5.0 leftovers

### DIFF
--- a/core/mesh/rtw_mesh.c
+++ b/core/mesh/rtw_mesh.c
@@ -2593,11 +2593,7 @@ void _rtw_mesh_expire_peer_ent(_adapter *adapter, struct mesh_plink_ent *plink)
 		struct wireless_dev *wdev = adapter->rtw_wdev;
 		s32 freq = rtw_ch2freq(mlmeext->cur_channel);
 
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
-		rtw_cfg80211_rx_mgmt(wdev, freq, 0, frame, flen, GFP_ATOMIC);
-		#else
-		cfg80211_rx_action(adapter->pnetdev, freq, frame, flen, GFP_ATOMIC);
-		#endif
+               rtw_cfg80211_rx_mgmt(wdev, freq, 0, frame, flen, GFP_ATOMIC);
 
 		rtw_mfree(frame, flen);
 	} else {

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -3879,15 +3879,9 @@ u8 ap_free_sta(_adapter *padapter, struct sta_info *psta, bool active, u16 reaso
 
 	if (!MLME_IS_MESH(padapter)) {
 #ifdef CONFIG_IOCTL_CFG80211
-		#ifdef COMPAT_KERNEL_RELEASE
-		rtw_cfg80211_indicate_sta_disassoc(padapter, psta->cmn.mac_addr, reason);
-		#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) && !defined(CONFIG_CFG80211_FORCE_COMPATIBLE_2_6_37_UNDER)
-		rtw_cfg80211_indicate_sta_disassoc(padapter, psta->cmn.mac_addr, reason);
-		#else /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) && !defined(CONFIG_CFG80211_FORCE_COMPATIBLE_2_6_37_UNDER) */
-		/* will call rtw_cfg80211_indicate_sta_disassoc() in cmd_thread for old API context */
-		#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) && !defined(CONFIG_CFG80211_FORCE_COMPATIBLE_2_6_37_UNDER) */
+               rtw_cfg80211_indicate_sta_disassoc(padapter, psta->cmn.mac_addr, reason);
 #else
-		rtw_indicate_sta_disassoc_event(padapter, psta);
+               rtw_indicate_sta_disassoc_event(padapter, psta);
 #endif
 	}
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -3348,16 +3348,10 @@ void rtw_iface_dynamic_check_timer_handlder(_adapter *adapter)
 
 
 #ifdef CONFIG_BR_EXT
-
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 35))
 	rcu_read_lock();
-#endif /* (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 35)) */
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35))
-	if (adapter->pnetdev->br_port
-#else	/* (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35)) */
+
 	if (rcu_dereference(adapter->pnetdev->rx_handler_data)
-#endif /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35)) */
 		&& (check_fwstate(pmlmepriv, WIFI_STATION_STATE | WIFI_ADHOC_STATE) == _TRUE)) {
 		/* expire NAT2.5 entry */
 		void nat25_db_expire(_adapter *priv);
@@ -3370,10 +3364,8 @@ void rtw_iface_dynamic_check_timer_handlder(_adapter *adapter)
 			adapter->pppoe_connection_in_progress--;
 	}
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 35))
-	rcu_read_unlock();
-#endif /* (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 35)) */
 
+rcu_read_unlock();
 #endif /* CONFIG_BR_EXT */
 
 }

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -1329,11 +1329,7 @@ void LeaveAllPowerSaveModeDirect(PADAPTER Adapter)
 		if (pwrpriv->rf_pwrstate == rf_off) {
 #ifdef CONFIG_AUTOSUSPEND
 			if (Adapter->registrypriv.usbss_enable) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-				usb_disable_autosuspend(adapter_to_dvobj(Adapter)->pusbdev);
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 34))
-				adapter_to_dvobj(Adapter)->pusbdev->autosuspend_disabled = Adapter->bDisableAutosuspend;/* autosuspend disabled by the user */
-#endif
+                               usb_disable_autosuspend(adapter_to_dvobj(Adapter)->pusbdev);
 			} else
 #endif
 			{
@@ -1401,11 +1397,7 @@ void LeaveAllPowerSaveMode(IN PADAPTER Adapter)
 		if (adapter_to_pwrctl(Adapter)->rf_pwrstate == rf_off) {
 #ifdef CONFIG_AUTOSUSPEND
 			if (Adapter->registrypriv.usbss_enable) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-				usb_disable_autosuspend(adapter_to_dvobj(Adapter)->pusbdev);
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 34))
-				adapter_to_dvobj(Adapter)->pusbdev->autosuspend_disabled = Adapter->bDisableAutosuspend;/* autosuspend disabled by the user */
-#endif
+                               usb_disable_autosuspend(adapter_to_dvobj(Adapter)->pusbdev);
 			} else
 #endif
 			{
@@ -2569,14 +2561,8 @@ int _rtw_pwr_wakeup(_adapter *padapter, u32 ips_deffer_ms, const char *caller)
 #if defined(CONFIG_BT_COEXIST) && defined (CONFIG_AUTOSUSPEND)
 		if (_TRUE == pwrpriv->bInternalAutoSuspend) {
 			if (0 == pwrpriv->autopm_cnt) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 33))
-				if (usb_autopm_get_interface(adapter_to_dvobj(padapter)->pusbintf) < 0)
-					RTW_INFO("can't get autopm:\n");
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20))
-				usb_autopm_disable(adapter_to_dvobj(padapter)->pusbintf);
-#else
-				usb_autoresume_device(adapter_to_dvobj(padapter)->pusbdev, 1);
-#endif
+                               if (usb_autopm_get_interface(adapter_to_dvobj(padapter)->pusbintf) < 0)
+                                       RTW_INFO("can't get autopm:\n");
 				pwrpriv->autopm_cnt++;
 			}
 #endif	/* #if defined (CONFIG_BT_COEXIST) && defined (CONFIG_AUTOSUSPEND) */

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -453,9 +453,7 @@ void rtw_os_recv_indicate_pkt(_adapter *padapter, _pkt *pkt, union recv_frame *r
 
 					/* skb->ip_summed = CHECKSUM_NONE; */
 					pkt->dev = pnetdev;
-					#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-					skb_set_queue_mapping(pkt, rtw_recv_select_queue(pkt));
-					#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35) */
+                                       skb_set_queue_mapping(pkt, rtw_recv_select_queue(pkt));
 
 					_rtw_xmit_entry(pkt, pnetdev);
 
@@ -476,13 +474,9 @@ void rtw_os_recv_indicate_pkt(_adapter *padapter, _pkt *pkt, union recv_frame *r
 #ifdef CONFIG_BR_EXT
 		if (check_fwstate(pmlmepriv, WIFI_STATION_STATE | WIFI_ADHOC_STATE) == _TRUE) {
 			/* Insert NAT2.5 RX here! */
-			#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35))
-			br_port = padapter->pnetdev->br_port;
-			#else
-			rcu_read_lock();
-			br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
-			rcu_read_unlock();
-			#endif
+                       rcu_read_lock();
+                       br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
+                       rcu_read_unlock();
 
 			if (br_port) {
 				int nat25_handle_frame(_adapter *priv, struct sk_buff *skb);

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -23,11 +23,7 @@
 #include <linux/platform_device.h>
 #include <linux/wlan_plat.h>
 #endif /* defined(RTW_ENABLE_WIFI_CONTROL_FUNC) */
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
 #define strnicmp	strncasecmp
-#endif /* Linux kernel >= 4.0.0 */
-
 #ifdef CONFIG_GPIO_WAKEUP
 #include <linux/interrupt.h>
 #include <linux/irq.h>
@@ -618,13 +614,9 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 #ifdef CONFIG_COMPAT
-#if (KERNEL_VERSION(4, 6, 0) > LINUX_VERSION_CODE)
-	if (is_compat_task()) {
-#else
-	if (in_compat_syscall()) {
-#endif
-		/* User space is 32-bit, use compat ioctl */
-		compat_android_wifi_priv_cmd compat_priv_cmd;
+       if (in_compat_syscall()) {
+               /* User space is 32-bit, use compat ioctl */
+               compat_android_wifi_priv_cmd compat_priv_cmd;
 
 		if (copy_from_user(&compat_priv_cmd, ifr->ifr_data, sizeof(compat_android_wifi_priv_cmd))) {
 			ret = -EFAULT;

--- a/os_dep/linux/rtw_rhashtable.c
+++ b/os_dep/linux/rtw_rhashtable.c
@@ -19,27 +19,7 @@
 
 int rtw_rhashtable_walk_enter(rtw_rhashtable *ht, rtw_rhashtable_iter *iter)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
-        return rhashtable_walk_init(ht, iter, GFP_ATOMIC);
-#else /* 4.4 <= kernel < 4.7 */
-        /* Older API lacks GFP parameter and requires manual setup */
-        iter->ht = ht;
-        iter->p = NULL;
-        iter->slot = 0;
-        iter->skip = 0;
-
-        iter->walker = kmalloc(sizeof(*iter->walker), GFP_ATOMIC);
-        if (!iter->walker)
-                return -ENOMEM;
-
-        spin_lock(&ht->lock);
-        iter->walker->tbl = rcu_dereference_protected(ht->tbl,
-                                                     lockdep_is_held(&ht->lock));
-        list_add(&iter->walker->list, &iter->walker->tbl->walkers);
-        spin_unlock(&ht->lock);
-
-        return 0;
-#endif
+       return rhashtable_walk_init(ht, iter, GFP_ATOMIC);
 }
 
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2090,17 +2090,13 @@ static int readFile(struct file *fp, char *buf, int len)
        if (!(fp->f_mode & FMODE_CAN_READ))
                return -EPERM;
 
-	while (sum < len) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+       while (sum < len) {
                rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
-#else
-               rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
-#endif
-		if (rlen > 0)
-			sum += rlen;
-		else if (0 != rlen)
-			return rlen;
-		else
+               if (rlen > 0)
+                       sum += rlen;
+               else if (0 != rlen)
+                       return rlen;
+               else
 			break;
 	}
 


### PR DESCRIPTION
## Summary
- drop legacy branches conditioned on very old kernels
- clean up Android and pwrctrl helpers
- rely only on modern kernel APIs for mesh and rx paths
- refresh rhashtable wrapper

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68443801004c8331ab0b7c51dd37a8f6