### PR TITLE
Remove obsolete kernel checks

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -84,59 +84,7 @@ static void rtw_dev_shutdown(struct device *dev)
 	}
 }
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 23))
-/* Some useful macros to use to create struct usb_device_id */
-#define USB_DEVICE_ID_MATCH_VENDOR			 0x0001
-#define USB_DEVICE_ID_MATCH_PRODUCT			 0x0002
-#define USB_DEVICE_ID_MATCH_DEV_LO			 0x0004
-#define USB_DEVICE_ID_MATCH_DEV_HI			 0x0008
-#define USB_DEVICE_ID_MATCH_DEV_CLASS			 0x0010
-#define USB_DEVICE_ID_MATCH_DEV_SUBCLASS		 0x0020
-#define USB_DEVICE_ID_MATCH_DEV_PROTOCOL		 0x0040
-#define USB_DEVICE_ID_MATCH_INT_CLASS			 0x0080
-#define USB_DEVICE_ID_MATCH_INT_SUBCLASS		 0x0100
-#define USB_DEVICE_ID_MATCH_INT_PROTOCOL		 0x0200
-#define USB_DEVICE_ID_MATCH_INT_NUMBER		 0x0400
 
-
-#define USB_DEVICE_ID_MATCH_INT_INFO \
-	(USB_DEVICE_ID_MATCH_INT_CLASS | \
-	 USB_DEVICE_ID_MATCH_INT_SUBCLASS | \
-	 USB_DEVICE_ID_MATCH_INT_PROTOCOL)
-
-
-#define USB_DEVICE_AND_INTERFACE_INFO(vend, prod, cl, sc, pr) \
-	.match_flags = USB_DEVICE_ID_MATCH_INT_INFO \
-		       | USB_DEVICE_ID_MATCH_DEVICE, \
-		       .idVendor = (vend), \
-				   .idProduct = (prod), \
-						.bInterfaceClass = (cl), \
-						.bInterfaceSubClass = (sc), \
-						.bInterfaceProtocol = (pr)
-
-/**
- * USB_VENDOR_AND_INTERFACE_INFO - describe a specific usb vendor with a class of usb interfaces
- * @vend: the 16 bit USB Vendor ID
- * @cl: bInterfaceClass value
- * @sc: bInterfaceSubClass value
- * @pr: bInterfaceProtocol value
- *
- * This macro is used to create a struct usb_device_id that matches a
- * specific vendor with a specific class of interfaces.
- *
- * This is especially useful when explicitly matching devices that have
- * vendor specific bDeviceClass values, but standards-compliant interfaces.
- */
-#define USB_VENDOR_AND_INTERFACE_INFO(vend, cl, sc, pr) \
-	.match_flags = USB_DEVICE_ID_MATCH_INT_INFO \
-		       | USB_DEVICE_ID_MATCH_VENDOR, \
-		       .idVendor = (vend), \
-				   .bInterfaceClass = (cl), \
-						   .bInterfaceSubClass = (sc), \
-						   .bInterfaceProtocol = (pr)
-
-/* ----------------------------------------------------------------------- */
-#endif
 
 
 #define USB_VENDER_ID_REALTEK		0x0BDA


### PR DESCRIPTION
## Summary
- remove legacy USB device macros referring to kernels < 2.6.23

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68443d9ed940833196d534098176f5e8