### PR TITLE
Remove obsolete pre-3.0 kernel paths

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -2884,11 +2884,7 @@ void rtw_stadel_event_callback(_adapter *adapter, u8 *pbuf)
 
 	if (MLME_IS_AP(adapter)) {
 #ifdef CONFIG_IOCTL_CFG80211
-#ifdef COMPAT_KERNEL_RELEASE
-
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 37)) || defined(CONFIG_CFG80211_FORCE_COMPATIBLE_2_6_37_UNDER)
-		rtw_cfg80211_indicate_sta_disassoc(adapter, pstadel->macaddr, *(u16 *)pstadel->rsvd);
-#endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 37)) || defined(CONFIG_CFG80211_FORCE_COMPATIBLE_2_6_37_UNDER) */
+               rtw_cfg80211_indicate_sta_disassoc(adapter, pstadel->macaddr, *(u16 *)pstadel->rsvd);
 #endif /* CONFIG_IOCTL_CFG80211 */
 
 		rtw_free_stainfo(adapter, psta);

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -4167,13 +4167,9 @@ int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
 
 		/* mac_clone_handle_frame(priv, skb); */
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35))
-		br_port = padapter->pnetdev->br_port;
-#else   /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35)) */
-		rcu_read_lock();
-		br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
-		rcu_read_unlock();
-#endif /* (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35)) */
+               rcu_read_lock();
+               br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
+               rcu_read_unlock();
 		_enter_critical_bh(&padapter->br_ext_lock, &irqL);
 		if (!(skb->data[0] & 1) &&
 		    br_port &&
@@ -4260,12 +4256,7 @@ int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
 				if (skb_is_nonlinear(skb))
 					DEBUG_ERR("%s(): skb_is_nonlinear!!\n", __FUNCTION__);
 
-
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 18))
-				res = skb_linearize(skb, GFP_ATOMIC);
-#else	/* (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 18)) */
-				res = skb_linearize(skb);
-#endif /* (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 18)) */
+                                res = skb_linearize(skb);
 				if (res < 0) {
 					DEBUG_ERR("TX DROP: skb_linearize fail!\n");
 					/* goto free_and_stop; */
@@ -4405,7 +4396,6 @@ static void do_queue_select(_adapter	*padapter, struct pkt_attrib *pattrib)
  *	0	success, hardware will handle this xmit frame(packet)
  *	<0	fail
  */
- #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
 s32 rtw_monitor_xmit_entry(struct sk_buff *skb, struct net_device *ndev)
 {
 	u16 frame_ctl;
@@ -4486,7 +4476,6 @@ fail:
 	rtw_skb_free(skb);
 	return 0;
 }
-#endif
 
 /*
  * The main transmit(tx) entry post handle
@@ -4596,14 +4585,9 @@ s32 rtw_xmit(_adapter *padapter, _pkt **ppkt)
 #ifdef CONFIG_BR_EXT
 	if (check_fwstate(&padapter->mlmepriv, WIFI_STATION_STATE | WIFI_ADHOC_STATE) == _TRUE) {
 		void *br_port = NULL;
-
-		#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35))
-		br_port = padapter->pnetdev->br_port;
-		#else
-		rcu_read_lock();
-		br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
-		rcu_read_unlock();
-		#endif
+                rcu_read_lock();
+                br_port = rcu_dereference(padapter->pnetdev->rx_handler_data);
+                rcu_read_unlock();
 
 		if (br_port) {
 			res = rtw_br_client_tx(padapter, ppkt);

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -23,9 +23,7 @@
 #include <linux/init.h>
 #include <linux/slab.h>
 #include <linux/module.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 5))
-	#include <linux/kref.h>
-#endif
+#include <linux/kref.h>
 /* #include <linux/smp_lock.h> */
 #include <linux/netdevice.h>
 #include <linux/inetdevice.h>
@@ -35,11 +33,7 @@
 #include <asm/byteorder.h>
 #include <asm/atomic.h>
 #include <asm/io.h>
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 26))
-	#include <asm/semaphore.h>
-#else
-	#include <linux/semaphore.h>
-#endif
+#include <linux/semaphore.h>
 #include <linux/sem.h>
 #include <linux/sched.h>
 #include <linux/etherdevice.h>
@@ -55,17 +49,12 @@
 #include <linux/list.h>
 #include <linux/vmalloc.h>
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 5, 41))
-	#include <linux/tqueue.h>
-#endif
 
 #include <uapi/linux/limits.h>
 
 #ifdef RTK_DMP_PLATFORM
-	#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 12))
-		#include <linux/pageremap.h>
-	#endif
-	#include <asm/io.h>
+       #include <linux/pageremap.h>
+       #include <asm/io.h>
 #endif
 
 #ifdef CONFIG_NET_RADIO
@@ -75,14 +64,8 @@
 /* Monitor mode */
 #include <net/ieee80211_radiotap.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-	#include <linux/ieee80211.h>
-#endif
+#include <linux/ieee80211.h>
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25) && \
-	 LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 29))
-	#define CONFIG_IEEE80211_HT_ADDT_INFO
-#endif
 
 #ifdef CONFIG_IOCTL_CFG80211
 	/*	#include <linux/ieee80211.h> */
@@ -99,12 +82,8 @@
 #endif
 
 #ifdef CONFIG_USB_HCI
-	#include <linux/usb.h>
-	#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 21))
-		#include <linux/usb_ch9.h>
-	#else
-		#include <linux/usb/ch9.h>
-	#endif
+       #include <linux/usb.h>
+       #include <linux/usb/ch9.h>
 #endif
 
 #ifdef CONFIG_BT_COEXIST_SOCKET_TRX
@@ -116,12 +95,10 @@
 #endif /* CONFIG_BT_COEXIST_SOCKET_TRX */
 
 #ifdef CONFIG_USB_HCI
-	typedef struct urb   *PURB;
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22))
-		#ifdef CONFIG_USB_SUSPEND
-			#define CONFIG_AUTOSUSPEND	1
-		#endif
-	#endif
+	typedef struct urb *PURB;
+#ifdef CONFIG_USB_SUSPEND
+	#define CONFIG_AUTOSUSPEND 1
+#endif
 #endif
 
 #if defined(CONFIG_RTW_GRO) && (!defined(CONFIG_RTW_NAPI))
@@ -131,27 +108,10 @@
 #endif
 
 
-#if (KERNEL_VERSION(2, 6, 29) > LINUX_VERSION_CODE && defined(CONFIG_RTW_NAPI))
-
-	#undef CONFIG_RTW_NAPI
-	/*#warning "Linux Kernel version too old to support NAPI (should newer than 2.6.29)\n"*/
-
-#endif
-
-#if (KERNEL_VERSION(2, 6, 33) > LINUX_VERSION_CODE && defined(CONFIG_RTW_GRO))
-
-	#undef CONFIG_RTW_GRO
-	/*#warning "Linux Kernel version too old to support GRO(should newer than 2.6.33)\n"*/
-
-#endif
 
 typedef struct	semaphore _sema;
 typedef	spinlock_t	_lock;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	typedef struct mutex		_mutex;
-#else
-	typedef struct semaphore	_mutex;
-#endif
+typedef struct mutex _mutex;
 struct rtw_timer_list {
 	struct timer_list timer;
 	void (*function)(void *);
@@ -183,9 +143,7 @@ typedef struct rcu_head rtw_rcu_head;
 #define rtw_rcu_assign_pointer(p, v) rcu_assign_pointer((p), (v))
 #define rtw_rcu_read_lock() rcu_read_lock()
 #define rtw_rcu_read_unlock() rcu_read_unlock()
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34))
 #define rtw_rcu_access_pointer(p) rcu_access_pointer(p)
-#endif
 
 /* rhashtable */
 #include "../os_dep/linux/rtw_rhashtable.h"
@@ -202,40 +160,11 @@ typedef void	*thread_context;
 typedef void timer_hdl_return;
 typedef void *timer_hdl_context;
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 41))
-	typedef struct work_struct _workitem;
-#else
-	typedef struct tq_struct _workitem;
-#endif
+typedef struct work_struct _workitem;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24))
-	#define DMA_BIT_MASK(n) (((n) == 64) ? ~0ULL : ((1ULL<<(n))-1))
-#endif
 
 typedef unsigned long systime;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 22))
-/* Porting from linux kernel, for compatible with old kernel. */
-static inline unsigned char *skb_tail_pointer(const struct sk_buff *skb)
-{
-	return skb->tail;
-}
-
-static inline void skb_reset_tail_pointer(struct sk_buff *skb)
-{
-	skb->tail = skb->data;
-}
-
-static inline void skb_set_tail_pointer(struct sk_buff *skb, const int offset)
-{
-	skb->tail = skb->data + offset;
-}
-
-static inline unsigned char *skb_end_pointer(const struct sk_buff *skb)
-{
-	return skb->end;
-}
-#endif
 
 __inline static void rtw_list_delete(_list *plist)
 {
@@ -301,12 +230,7 @@ __inline static void exit_critical_bh(_lock *plock)
 __inline static int _enter_critical_mutex(_mutex *pmutex, _irqL *pirqL)
 {
 	int ret = 0;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	/* mutex_lock(pmutex); */
-	ret = mutex_lock_interruptible(pmutex);
-#else
-	ret = down_interruptible(pmutex);
-#endif
+ret = mutex_lock_interruptible(pmutex);
 	return ret;
 }
 
@@ -314,21 +238,13 @@ __inline static int _enter_critical_mutex(_mutex *pmutex, _irqL *pirqL)
 __inline static int _enter_critical_mutex_lock(_mutex *pmutex, _irqL *pirqL)
 {
 	int ret = 0;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	mutex_lock(pmutex);
-#else
-	down(pmutex);
-#endif
+mutex_lock(pmutex);
 	return ret;
 }
 
 __inline static void _exit_critical_mutex(_mutex *pmutex, _irqL *pirqL)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
-	mutex_unlock(pmutex);
-#else
-	up(pmutex);
-#endif
+mutex_unlock(pmutex);
 }
 
 __inline static _list	*get_list_head(_queue	*queue)
@@ -377,33 +293,17 @@ __inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled)
 
 static inline void _init_workitem(_workitem *pwork, void *pfunc, void *cntx)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20))
-	INIT_WORK(pwork, pfunc);
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 41))
-	INIT_WORK(pwork, pfunc, pwork);
-#else
-	INIT_TQUEUE(pwork, pfunc, pwork);
-#endif
+INIT_WORK(pwork, pfunc);
 }
 
 __inline static void _set_workitem(_workitem *pwork)
 {
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 41))
-	schedule_work(pwork);
-#else
-	schedule_task(pwork);
-#endif
+schedule_work(pwork);
 }
 
 __inline static void _cancel_workitem_sync(_workitem *pwork)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22))
-	cancel_work_sync(pwork);
-#elif (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 41))
-	flush_scheduled_work();
-#else
-	flush_scheduled_tasks();
-#endif
+cancel_work_sync(pwork);
 }
 /*
  * Global Mutex: can only be used at PASSIVE level.
@@ -424,41 +324,25 @@ __inline static void _cancel_workitem_sync(_workitem *pwork)
 
 static inline int rtw_netif_queue_stopped(struct net_device *pnetdev)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-	return (netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 0)) &&
-		netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 1)) &&
-		netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 2)) &&
-		netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 3)));
-#else
-	return netif_queue_stopped(pnetdev);
-#endif
+return (netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 0)) &&
+       netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 1)) &&
+       netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 2)) &&
+       netif_tx_queue_stopped(netdev_get_tx_queue(pnetdev, 3)));
 }
 
 static inline void rtw_netif_wake_queue(struct net_device *pnetdev)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-	netif_tx_wake_all_queues(pnetdev);
-#else
-	netif_wake_queue(pnetdev);
-#endif
+netif_tx_wake_all_queues(pnetdev);
 }
 
 static inline void rtw_netif_start_queue(struct net_device *pnetdev)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-	netif_tx_start_all_queues(pnetdev);
-#else
-	netif_start_queue(pnetdev);
-#endif
+netif_tx_start_all_queues(pnetdev);
 }
 
 static inline void rtw_netif_stop_queue(struct net_device *pnetdev)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-	netif_tx_stop_all_queues(pnetdev);
-#else
-	netif_stop_queue(pnetdev);
-#endif
+netif_tx_stop_all_queues(pnetdev);
 }
 static inline void rtw_netif_device_attach(struct net_device *pnetdev)
 {
@@ -486,11 +370,7 @@ static inline int rtw_merge_string(char *dst, int dst_len, const char *src1, con
 	return len;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27))
-	#define rtw_signal_process(pid, sig) kill_pid(find_vpid((pid)), (sig), 1)
-#else /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) */
-	#define rtw_signal_process(pid, sig) kill_proc((pid), (sig), 1)
-#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) */
+#define rtw_signal_process(pid, sig) kill_pid(find_vpid((pid)), (sig), 1)
 
 
 /* Suspend lock prevent system from going suspend */

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -22,10 +22,6 @@
 #include "../../hal/hal_halmac.h"
 #endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 27))
-#define  iwe_stream_add_event(a, b, c, d, e)  iwe_stream_add_event(b, c, d, e)
-#define  iwe_stream_add_point(a, b, c, d, e)  iwe_stream_add_point(b, c, d, e)
-#endif
 
 #ifdef CONFIG_80211N_HT
 extern int rtw_ht_enable;
@@ -162,11 +158,7 @@ static void request_wps_pbc_event(_adapter *padapter)
 void rtw_request_wps_pbc_event(_adapter *padapter)
 {
 #ifdef RTK_DMP_PLATFORM
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 12))
-	kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_NET_PBC);
-#else
-	kobject_hotplug(&padapter->pnetdev->class_dev.kobj, KOBJ_NET_PBC);
-#endif
+       kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_NET_PBC);
 #else
 
 	if (padapter->pid[0] == 0) {
@@ -1387,13 +1379,9 @@ static int rtw_wx_set_mode(struct net_device *dev, struct iw_request_info *a,
 		dev->type = ARPHRD_IEEE80211; /* IEEE 802.11 : 801 */
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-		dev->type = ARPHRD_IEEE80211_RADIOTAP; /* IEEE 802.11 + radiotap header : 803 */
-		RTW_INFO("set_mode = IW_MODE_MONITOR\n");
-#else
-		RTW_INFO("kernel version < 2.6.24 not support IW_MODE_MONITOR\n");
-#endif
-		break;
+               dev->type = ARPHRD_IEEE80211_RADIOTAP; /* IEEE 802.11 + radiotap header : 803 */
+               RTW_INFO("set_mode = IW_MODE_MONITOR\n");
+               break;
 
 	case IW_MODE_AUTO:
 		networkType = Ndis802_11AutoUnknown;
@@ -12384,17 +12372,7 @@ static struct iw_statistics *rtw_get_wireless_stats(struct net_device *dev)
 		piwstats->qual.qual = tmp_qual;
 		piwstats->qual.noise = tmp_noise;
 	}
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 14))
-	piwstats->qual.updated = IW_QUAL_ALL_UPDATED ;/* |IW_QUAL_DBM; */
-#else
-#ifdef RTK_DMP_PLATFORM
-	/* IW_QUAL_DBM= 0x8, if driver use this flag, wireless extension will show value of dbm. */
-	/* remove this flag for show percentage 0~100 */
-	piwstats->qual.updated = 0x07;
-#else
-	piwstats->qual.updated = 0x0f;
-#endif
-#endif
+       piwstats->qual.updated = IW_QUAL_ALL_UPDATED;
 
 #ifdef CONFIG_SIGNAL_DISPLAY_DBM
 	piwstats->qual.updated = piwstats->qual.updated | IW_QUAL_DBM;
@@ -12408,7 +12386,7 @@ static struct iw_statistics *rtw_get_wireless_stats(struct net_device *dev)
 struct iw_handler_def rtw_handlers_def = {
 	.standard = rtw_handlers,
 	.num_standard = sizeof(rtw_handlers) / sizeof(iw_handler),
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)) || defined(CONFIG_WEXT_PRIV)
+#if defined(CONFIG_WEXT_PRIV)
 	.private = rtw_private_handler,
 	.private_args = (struct iw_priv_args *)rtw_private_args,
 	.num_private = sizeof(rtw_private_handler) / sizeof(iw_handler),


### PR DESCRIPTION
## Summary
- drop conditional code for kernels older than 3.0
- keep only modern implementations in osdep helpers
- simplify core code now that old branches are gone

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844670a9da48331bb1fd67ab27ec3ea