### PR TITLE
Remove outdated kernel checks

### DIFF
--- a/core/mesh/rtw_mesh.h
+++ b/core/mesh/rtw_mesh.h
@@ -521,12 +521,8 @@ int rtw_mesh_rx_msdu_act_check(union recv_frame *rframe
 
 void dump_mesh_stats(void *sel, _adapter *adapter);
 
-#if defined(PLATFORM_LINUX) && (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32))
 #define rtw_lockdep_assert_held(l) lockdep_assert_held(l)
 #define rtw_lockdep_is_held(l) lockdep_is_held(l)
-#else
-#error "TBD\n"
-#endif
 
 #include "rtw_mesh_pathtbl.h"
 #include "rtw_mesh_hwmp.h"

--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -43,11 +43,7 @@
 		#include <linux/ipv6.h>
 		#include <linux/icmpv6.h>
 		#include <net/ndisc.h>
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-			#include <net/ip6_checksum.h>
-		#else
-			#include <net/checksum.h>
-		#endif
+               #include <net/ip6_checksum.h>
 	#endif
 #endif
 

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -47,11 +47,9 @@ void dump_drv_version(void *sel)
 
 void dump_drv_cfg(void *sel)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-	char *kernel_version = utsname()->release;
+       char *kernel_version = utsname()->release;
 
-	RTW_PRINT_SEL(sel, "\nKernel Version: %s\n", kernel_version);
-#endif
+       RTW_PRINT_SEL(sel, "\nKernel Version: %s\n", kernel_version);
 
 	RTW_PRINT_SEL(sel, "Driver Version: %s\n", DRIVERVERSION);
 	RTW_PRINT_SEL(sel, "------------------------------------------------\n");

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -4245,7 +4245,6 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 	return ret;
 
 }
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
 int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
@@ -4265,7 +4264,6 @@ int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
 		rtw_free_recvframe(rframe, pfree_recv_queue); /* free this recv_frame */
 		goto exit;
 	}
-#endif
 	/* write skb information to recv frame */
 	skb_reset_mac_header(pskb);
 	rframe->u.hdr.len = pskb->len;
@@ -4450,9 +4448,7 @@ int recv_func(_adapter *padapter, union recv_frame *rframe)
 #endif
 	if (check_fwstate(mlmepriv, WIFI_MONITOR_STATE)) {
 		/* monitor mode */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-		recv_frame_monitor(padapter, rframe);
-#endif
+               recv_frame_monitor(padapter, rframe);
 		ret = _SUCCESS;
 		goto exit;
 	} else

--- a/include/rtw_xmit.h
+++ b/include/rtw_xmit.h
@@ -987,9 +987,7 @@ void _rtw_free_xmit_priv(struct xmit_priv *pxmitpriv);
 
 void rtw_alloc_hwxmits(_adapter *padapter);
 void rtw_free_hwxmits(_adapter *padapter);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
 s32 rtw_monitor_xmit_entry(struct sk_buff *skb, struct net_device *ndev);
-#endif
 s32 rtw_xmit_posthandle(_adapter *padapter, struct xmit_frame *pxmitframe, _pkt *pkt);
 s32 rtw_xmit(_adapter *padapter, _pkt **pkt);
 bool xmitframe_hiq_filter(struct xmit_frame *xmitframe);

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -27,11 +27,7 @@ void Linkup_workitem_callback(struct work_struct *work)
 
 
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 12))
-	kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_LINKUP);
-#else
-	kobject_hotplug(&padapter->pnetdev->class_dev.kobj, KOBJ_LINKUP);
-#endif
+       kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_LINKUP);
 
 }
 
@@ -42,11 +38,7 @@ void Linkdown_workitem_callback(struct work_struct *work)
 
 
 
-#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 12))
-	kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_LINKDOWN);
-#else
-	kobject_hotplug(&padapter->pnetdev->class_dev.kobj, KOBJ_LINKDOWN);
-#endif
+       kobject_uevent(&padapter->pnetdev->dev.kobj, KOBJ_LINKDOWN);
 
 }
 #endif
@@ -326,18 +318,16 @@ static int mgnt_netdev_close(struct net_device *pnetdev)
 	return 0;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))
 static const struct net_device_ops rtl871x_mgnt_netdev_ops = {
-	.ndo_open = mgnt_netdev_open,
-	.ndo_stop = mgnt_netdev_close,
-	.ndo_start_xmit = mgnt_xmit_entry,
-	#if 0
-	.ndo_set_mac_address = r871x_net_set_mac_address,
-	.ndo_get_stats = r871x_net_get_stats,
-	.ndo_do_ioctl = r871x_mp_ioctl,
-	#endif
+        .ndo_open = mgnt_netdev_open,
+        .ndo_stop = mgnt_netdev_close,
+        .ndo_start_xmit = mgnt_xmit_entry,
+        #if 0
+        .ndo_set_mac_address = r871x_net_set_mac_address,
+        .ndo_get_stats = r871x_net_get_stats,
+        .ndo_do_ioctl = r871x_mp_ioctl,
+        #endif
 };
-#endif
 
 int hostapd_mode_init(_adapter *padapter)
 {
@@ -361,27 +351,9 @@ int hostapd_mode_init(_adapter *padapter)
 
 	/* pnetdev->init = NULL; */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))
+       RTW_INFO("register rtl871x_mgnt_netdev_ops to netdev_ops\n");
 
-	RTW_INFO("register rtl871x_mgnt_netdev_ops to netdev_ops\n");
-
-	pnetdev->netdev_ops = &rtl871x_mgnt_netdev_ops;
-
-#else
-
-	pnetdev->open = mgnt_netdev_open;
-
-	pnetdev->stop = mgnt_netdev_close;
-
-	pnetdev->hard_start_xmit = mgnt_xmit_entry;
-
-	/* pnetdev->set_mac_address = r871x_net_set_mac_address; */
-
-	/* pnetdev->get_stats = r871x_net_get_stats; */
-
-	/* pnetdev->do_ioctl = r871x_mp_ioctl; */
-
-#endif
+       pnetdev->netdev_ops = &rtl871x_mgnt_netdev_ops;
 
 	pnetdev->watchdog_timeo = HZ; /* 1 second timeout */
 


### PR DESCRIPTION
## Summary
- drop conditional compilation for kernels older than 4.0
- use modern netdev hooks for mgmt interface
- simplify debug and monitor helpers

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844854f64f083319bde270fddfaa260