### PR TITLE
Clean old kernel macros

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -42,12 +42,10 @@
 #endif
 
 #ifdef PLATFORM_LINUX
-	#include <linux/version.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
-	#include <linux/sched/signal.h>
-	#include <linux/sched/types.h>
-#endif
-	#include <osdep_service_linux.h>
+       #include <linux/version.h>
+       #include <linux/sched/signal.h>
+       #include <linux/sched/types.h>
+       #include <osdep_service_linux.h>
 #endif
 
 #ifdef PLATFORM_OS_XP


### PR DESCRIPTION
## Summary
- drop outdated kernel version checks
- rely on modern netdevice operations headers

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68449df572d483319e4742a5d6c504de