### PR TITLE
core: drop eCos remnants

### DIFF
--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -4315,22 +4315,6 @@ void phydm_cmd_parser(struct dm_struct *dm, char input[][MAX_ARGV],
 #endif /*@#ifdef CONFIG_PHYDM_DEBUG_FUNCTION*/
 }
 
-#if defined __ECOS || defined __ICCARM__
-char *strsep(char **s, const char *ct)
-{
-	char *sbegin = *s;
-	char *end;
-
-	if (!sbegin)
-		return NULL;
-
-	end = strpbrk(sbegin, ct);
-	if (end)
-		*end++ = '\0';
-	*s = end;
-	return sbegin;
-}
-#endif
 
 #if (DM_ODM_SUPPORT_TYPE & (ODM_CE | ODM_AP | ODM_IOT))
 s32 phydm_cmd(struct dm_struct *dm, char *input, u32 in_len, u8 flag,

--- a/hal/phydm/phydm_interface.h
+++ b/hal/phydm/phydm_interface.h
@@ -121,18 +121,10 @@ ODM_REG(DIG,_pdm_odm)
 #define _bit_11N(_name)			ODM_BIT_##_name##_11N
 #define _bit_11AC(_name)		ODM_BIT_##_name##_11AC
 
-#ifdef __ECOS
-#define _rtk_cat(_name, _ic_type, _func)                                \
-	(                                                               \
-		((_ic_type) & ODM_IC_11N_SERIES) ? _func##_11N(_name) : \
-						   _func##_11AC(_name))
-#else
-
 #define _cat(_name, _ic_type, _func)                                    \
-	(                                                               \
-		((_ic_type) & ODM_IC_11N_SERIES) ? _func##_11N(_name) : \
-						   _func##_11AC(_name))
-#endif
+       (                                                               \
+               ((_ic_type) & ODM_IC_11N_SERIES) ? _func##_11N(_name) : \
+                                                  _func##_11AC(_name))
 /*@
  * only sample code
  *#define _cat(_name, _ic_type, _func)					\
@@ -147,17 +139,10 @@ ODM_REG(DIG,_pdm_odm)
  * gets "ODM_R_A_AGC_CORE1" or "ODM_R_A_AGC_CORE1_8192C",
  * depends on support_ic_type.
  */
-#ifdef __ECOS
-	#define ODM_REG(_name, _pdm_odm)	\
-		_rtk_cat(_name, _pdm_odm->support_ic_type, _reg)
-	#define ODM_BIT(_name, _pdm_odm)	\
-		_rtk_cat(_name, _pdm_odm->support_ic_type, _bit)
-#else
-	#define ODM_REG(_name, _pdm_odm)	\
-		_cat(_name, _pdm_odm->support_ic_type, _reg)
-	#define ODM_BIT(_name, _pdm_odm)	\
-		_cat(_name, _pdm_odm->support_ic_type, _bit)
-#endif
+#define ODM_REG(_name, _pdm_odm) \
+       _cat(_name, _pdm_odm->support_ic_type, _reg)
+#define ODM_BIT(_name, _pdm_odm) \
+       _cat(_name, _pdm_odm->support_ic_type, _bit)
 
 #endif
 /*@


### PR DESCRIPTION
## Summary
- drop unused eCos strsep helper
- simplify ODM macros after removing `__ECOS` guards
- build driver against Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845b915433c833181a10375f19d3555