### PR TITLE
Remove unused FreeBSD stubs

### DIFF
--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -14,9 +14,6 @@
  *****************************************************************************/
 #define _RTW_MP_C_
 #include <drv_types.h>
-#ifdef PLATFORM_FREEBSD
-	#include <sys/unistd.h>		/* for RFHIGHPID */
-#endif
 
 #include "../hal/phydm/phydm_precomp.h"
 #if defined(CONFIG_RTL8723B) || defined(CONFIG_RTL8821A)
@@ -2091,17 +2088,6 @@ void SetPacketTx(PADAPTER padapter)
 	if (IS_ERR(pmp_priv->tx.PktTxThread)) {
 		RTW_ERR("Create PktTx Thread Fail !!!!!\n");
 		pmp_priv->tx.PktTxThread = NULL;
-	}
-#endif
-#ifdef PLATFORM_FREEBSD
-	{
-		struct proc *p;
-		struct thread *td;
-		pmp_priv->tx.PktTxThread = kproc_kthread_add(mp_xmit_packet_thread, pmp_priv,
-			&p, &td, RFHIGHPID, 0, "MPXmitThread", "MPXmitThread");
-
-		if (pmp_priv->tx.PktTxThread < 0)
-			RTW_INFO("Create PktTx Thread Fail !!!!!\n");
 	}
 #endif
 


### PR DESCRIPTION
## Summary
- remove `<sys/unistd.h>` include
- drop FreeBSD thread creation code

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eef3416c8331b165935b8ff56f4b