### PR TITLE
Remove FreeBSD guards from security module

### DIFF
--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -2130,7 +2130,6 @@ BIP_exit:
 }
 #endif /* CONFIG_IEEE80211W */
 
-#ifndef PLATFORM_FREEBSD
 #if defined(CONFIG_TDLS)
 /* compress 512-bits */
 static int sha256_compress(struct sha256_state *md, unsigned char *buf)
@@ -2406,7 +2405,6 @@ static void hmac_sha256_vector(u8 *key, size_t key_len, size_t num_elem,
 	sha256_vector(2, _addr, _len, mac);
 }
 #endif /* CONFIG_TDLS */
-#endif /* PLATFORM_FREEBSD */
 /**
  * sha256_prf - SHA256-based Pseudo-Random Function (IEEE 802.11r, 8.5.1.5.2)
  * @key: Key for PRF
@@ -2420,7 +2418,6 @@ static void hmac_sha256_vector(u8 *key, size_t key_len, size_t num_elem,
  * This function is used to derive new, cryptographically separate keys from a
  * given key.
  */
-#ifndef PLATFORM_FREEBSD /* Baron */
 #if defined(CONFIG_TDLS)
 static void sha256_prf(u8 *key, size_t key_len, char *label,
 		       u8 *data, size_t data_len, u8 *buf, size_t buf_len)
@@ -2459,7 +2456,6 @@ static void sha256_prf(u8 *key, size_t key_len, char *label,
 	}
 }
 #endif
-#endif /* PLATFORM_FREEBSD Baron */
 
 /* AES tables*/
 const u32 Te0[256] = {
@@ -2638,7 +2634,6 @@ const u8 rcons[] = {
  *
  * @return	the number of rounds for the given cipher key size.
  */
-#ifndef PLATFORM_FREEBSD /* Baron */
 static void rijndaelKeySetupEnc(u32 rk[/*44*/], const u8 cipherKey[])
 {
 	int i;
@@ -2855,7 +2850,6 @@ int omac1_aes_128(const u8 *key, const u8 *data, size_t data_len, u8 *mac)
 {
 	return omac1_aes_128_vector(key, 1, &data, &data_len, mac);
 }
-#endif /* PLATFORM_FREEBSD Baron */
 
 #ifdef CONFIG_RTW_MESH_AEK
 /* for AES-SIV */


### PR DESCRIPTION
## Summary
- strip `#ifndef PLATFORM_FREEBSD` wrappers in `rtw_security.c`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef05b780833190cc0dce804d522c