### PR TITLE
Remove FreeBSD swab variants

### DIFF
--- a/include/byteorder/swab.h
+++ b/include/byteorder/swab.h
@@ -104,21 +104,14 @@ __inline static __u64 __arch__swab64(__u64 x)
 	#define __swab64(x) __fswab64(x)
 #endif /* __swab16 */
 
-#ifdef PLATFORM_FREEBSD
-	__inline static __u16 __fswab16(__u16 x)
-#else
-	__inline static const __u16 __fswab16(__u16 x)
-#endif /* PLATFORM_FREEBSD */
+__inline static __u16 __fswab16(__u16 x)
 {
-	return __arch__swab16(x);
+        return __arch__swab16(x);
 }
-#ifdef PLATFORM_FREEBSD
-	__inline static __u32 __fswab32(__u32 x)
-#else
-	__inline static const __u32 __fswab32(__u32 x)
-#endif /* PLATFORM_FREEBSD */
+
+__inline static __u32 __fswab32(__u32 x)
 {
-	return __arch__swab32(x);
+        return __arch__swab32(x);
 }
 
 #if defined(PLATFORM_LINUX) || defined(PLATFORM_WINDOWS)


### PR DESCRIPTION
## Summary
- remove conditional FreeBSD versions of `__fswab16` and `__fswab32`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: `flex` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef2115dc8331acb05a7111cdb199