### PR TITLE
core: drop FreeBSD tasklet and skb paths

### DIFF
--- a/hal/hal_hci/hal_usb.c
+++ b/hal/hal_hci/hal_usb.c
@@ -29,11 +29,6 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 		     (unsigned long)padapter);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-#ifdef CONFIG_RX_INDICATE_QUEUE
-	TASK_INIT(&precvpriv->rx_indicate_tasklet, 0, rtw_rx_indicate_tasklet, padapter);
-#endif /* CONFIG_RX_INDICATE_QUEUE */
-#endif /* PLATFORM_FREEBSD */
 
 #ifdef CONFIG_USB_INTERRUPT_IN_PIPE
 #ifdef PLATFORM_LINUX
@@ -93,7 +88,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 	precvpriv->free_recv_buf_queue_cnt = NR_RECVBUFF;
 
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_FREEBSD)
+#ifdef PLATFORM_LINUX
 
 	skb_queue_head_init(&precvpriv->rx_skb_queue);
 
@@ -122,11 +117,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 #endif /* CONFIG_PREALLOC_RX_SKB_BUFFER */
 
 			if (pskb) {
-#ifdef PLATFORM_FREEBSD
-				pskb->dev = padapter->pifp;
-#else
-				pskb->dev = padapter->pnetdev;
-#endif /* PLATFORM_FREEBSD */
+                                pskb->dev = padapter->pnetdev;
 
 #ifndef CONFIG_PREALLOC_RX_SKB_BUFFER
 				tmpaddr = (SIZE_PTR)pskb->data;
@@ -139,7 +130,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 	}
 #endif /* CONFIG_PREALLOC_RECV_SKB */
 
-#endif /* defined(PLATFORM_LINUX) || defined(PLATFORM_FREEBSD) */
+#endif /* PLATFORM_LINUX */
 
 exit:
 
@@ -198,27 +189,6 @@ void usb_free_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	struct sk_buff  *pskb;
-	while (NULL != (pskb = skb_dequeue(&precvpriv->rx_skb_queue)))
-		rtw_skb_free(pskb);
-
-#if !defined(CONFIG_USE_USB_BUFFER_ALLOC_RX)
-	rtw_skb_queue_purge(&precvpriv->free_recv_skb_queue);
-#endif
-
-#ifdef CONFIG_RX_INDICATE_QUEUE
-	struct mbuf *m;
-	for (;;) {
-		IF_DEQUEUE(&precvpriv->rx_indicate_queue, m);
-		if (m == NULL)
-			break;
-		rtw_os_pkt_free(m);
-	}
-	mtx_destroy(&precvpriv->rx_indicate_queue.ifq_mtx);
-#endif /* CONFIG_RX_INDICATE_QUEUE */
-
-#endif /* PLATFORM_FREEBSD */
 }
 
 #ifdef CONFIG_FW_C2H_REG

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -398,25 +398,19 @@ struct recv_priv {
 #endif /* CONFIG_USB_INTERRUPT_IN_PIPE */
 
 #endif
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_FREEBSD)
-#ifdef PLATFORM_FREEBSD
-	struct task irq_prepare_beacon_tasklet;
-	struct task recv_tasklet;
-#else /* PLATFORM_FREEBSD */
-	struct tasklet_struct irq_prepare_beacon_tasklet;
-	struct tasklet_struct recv_tasklet;
-#endif /* PLATFORM_FREEBSD */
-	struct sk_buff_head free_recv_skb_queue;
-	struct sk_buff_head rx_skb_queue;
+#ifdef PLATFORM_LINUX
+        struct tasklet_struct irq_prepare_beacon_tasklet;
+        struct tasklet_struct recv_tasklet;
+        struct sk_buff_head free_recv_skb_queue;
+        struct sk_buff_head rx_skb_queue;
 #ifdef CONFIG_RTW_NAPI
-		struct sk_buff_head rx_napi_skb_queue;
-#endif 
+                struct sk_buff_head rx_napi_skb_queue;
+#endif
 #ifdef CONFIG_RX_INDICATE_QUEUE
-	struct task rx_indicate_tasklet;
-	struct ifqueue rx_indicate_queue;
+        struct task rx_indicate_tasklet;
+        struct ifqueue rx_indicate_queue;
 #endif /* CONFIG_RX_INDICATE_QUEUE */
-
-#endif /* defined(PLATFORM_LINUX) || defined(PLATFORM_FREEBSD) */
+#endif /* PLATFORM_LINUX */
 
 	u8 *pallocated_recv_buf;
 	u8 *precv_buf;    /* 4 alignment */
@@ -551,9 +545,7 @@ struct recv_buf {
 #endif
 
 #if defined(PLATFORM_LINUX)
-	_pkt *pskb;
-#elif defined(PLATFORM_FREEBSD) /* skb solution */
-	struct sk_buff *pskb;
+        _pkt *pskb;
 #endif
 };
 

--- a/include/rtw_xmit.h
+++ b/include/rtw_xmit.h
@@ -800,10 +800,7 @@ struct	xmit_priv	{
 	/*	USB_TRANSFER	usb_transfer_write_mem; */
 #endif
 #ifdef PLATFORM_LINUX
-	struct tasklet_struct xmit_tasklet;
-#endif
-#ifdef PLATFORM_FREEBSD
-	struct task xmit_tasklet;
+        struct tasklet_struct xmit_tasklet;
 #endif
 	/* per AC pending irp */
 	int beq_cnt;


### PR DESCRIPTION
## Summary
- remove FreeBSD-specific tasklet definitions
- drop FreeBSD skb allocation logic
- rely on Linux code for USB Rx skb queues
- clean up FreeBSD memory free macros

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845ef0fb2388331ab70ec941c83403e