### PR TITLE
Remove FreeBSD adapter members

### DIFF
--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -1193,10 +1193,6 @@ struct dvobj_priv {
 	struct usb_device *pusbdev;
 #endif/* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	struct usb_interface *pusbintf;
-	struct usb_device *pusbdev;
-#endif/* PLATFORM_FREEBSD */
 
 #endif/* CONFIG_USB_HCI */
 
@@ -1574,11 +1570,6 @@ struct _ADAPTER {
 
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	_nic_hdl pifp;
-	int bup;
-	_lock glock;
-#endif /* PLATFORM_FREEBSD */
 	u8 mac_addr[ETH_ALEN];
 	int net_closed;
 


### PR DESCRIPTION
## Summary
- remove the leftover FreeBSD block in `struct _ADAPTER`
- install required build tools and compile against Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845ef25f77083319ec176db64f6d95b