### PR TITLE
Remove FreeBSD rtw_ioctl prototype

### DIFF
--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -135,9 +135,6 @@ void rtw_set_rtnl_lock_holder(struct dvobj_priv *dvobj, _thread_hdl_ thd_hdl);
 #endif /* PLATFORM_LINUX */
 
 
-#ifdef PLATFORM_FREEBSD
-extern int rtw_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data);
-#endif
 
 void rtw_ips_dev_unload(_adapter *padapter);
 


### PR DESCRIPTION
## Summary
- drop unused FreeBSD `rtw_ioctl` prototype

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef35033483318f1ff07b0ff77d12