### PR TITLE
Remove FreeBSD guard for HT

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -423,7 +423,7 @@ struct ieee_ibss_seq {
 	_list	list;
 };
 
-#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8711FW) || defined(PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8711FW)
 
 struct rtw_ieee80211_hdr {
 	u16 frame_ctl;
@@ -654,7 +654,7 @@ enum eap_type {
 
 #define P80211_OUI_LEN 3
 
-#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8711FW) || defined(PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8711FW)
 
 struct ieee80211_snap_hdr {
 

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -808,7 +808,7 @@ struct rtw_ieee80211_bar {
 #define IEEE80211_BAR_CTRL_CBMTID_COMPRESSED_BA  0x0004
 
 
-#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8712FW) || defined(PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX) || defined(CONFIG_RTL8712FW)
 
 
 


### PR DESCRIPTION
## Summary
- remove PLATFORM_FREEBSD from the HT capability sections

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef575664833181070cf734b28470