### PR TITLE
Remove FreeBSD NDIS type definitions

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -69,7 +69,6 @@
 
 #endif
 
-
 #ifdef PLATFORM_LINUX
 	#include <linux/version.h>
 	#include <linux/types.h>
@@ -134,50 +133,6 @@
 
 #endif
 
-
-#ifdef PLATFORM_FREEBSD
-
-	typedef signed char s8;
-	typedef unsigned char u8;
-
-	typedef signed short s16;
-	typedef unsigned short u16;
-
-	typedef signed int s32;
-	typedef unsigned int u32;
-
-	typedef unsigned int	uint;
-	typedef	signed int		sint;
-	typedef long atomic_t;
-
-	typedef signed long long s64;
-	typedef unsigned long long u64;
-	#define IN
-	#define OUT
-	#define VOID void
-	#define NDIS_OID uint
-	#define NDIS_STATUS uint
-
-	#ifndef	PVOID
-		typedef void *PVOID;
-		/* #define PVOID	(void *) */
-	#endif
-	typedef u32 dma_addr_t;
-	#define UCHAR u8
-	#define USHORT u16
-	#define UINT u32
-	#define ULONG u32
-
-	typedef void (*proc_t)(void *);
-
-	typedef unsigned int __kernel_size_t;
-	typedef int __kernel_ssize_t;
-
-	typedef	__kernel_size_t	SIZE_T;
-	typedef	__kernel_ssize_t	SSIZE_T;
-	#define FIELD_OFFSET(s, field)	((SSIZE_T)&((s *)(0))->field)
-
-#endif
 
 #define MEM_ALIGNMENT_OFFSET	(sizeof (SIZE_T))
 #define MEM_ALIGNMENT_PADDING	(sizeof(SIZE_T) - 1)


### PR DESCRIPTION
## Summary
- remove obsolete FreeBSD NDIS typedef block from `basic_types.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef5e3a208331b6ee3e3e38c2e577