### PR TITLE
Remove FreeBSD xmit entry prototypes

### DIFF
--- a/include/xmit_osdep.h
+++ b/include/xmit_osdep.h
@@ -51,12 +51,6 @@ extern NDIS_STATUS rtw_xmit_entry(
 
 #endif /* PLATFORM_WINDOWS */
 
-#ifdef PLATFORM_FREEBSD
-#define NR_XMITFRAME	256
-extern int rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev);
-extern void rtw_xmit_entry_wrap(struct ifnet *pifp);
-#endif /* PLATFORM_FREEBSD */
-
 #ifdef PLATFORM_LINUX
 
 #define NR_XMITFRAME	256


### PR DESCRIPTION
## Summary
- remove unused FreeBSD xmit entry declarations and NR_XMITFRAME definition

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: `aarch64-linux-gnu-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef63874c8331a679b576c9b87981