### PR TITLE
osdep: drop FreeBSD code paths

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -79,9 +79,6 @@ inline void *_rtw_vmalloc(u32 sz)
 #ifdef PLATFORM_LINUX
 	pbuf = vmalloc(sz);
 #endif
-#ifdef PLATFORM_FREEBSD
-	pbuf = malloc(sz, M_DEVBUF, M_NOWAIT);
-#endif
 
 #ifdef PLATFORM_WINDOWS
 	NdisAllocateMemoryWithTag(&pbuf, sz, RT_TAG);
@@ -107,9 +104,6 @@ inline void *_rtw_zvmalloc(u32 sz)
 	if (pbuf != NULL)
 		memset(pbuf, 0, sz);
 #endif
-#ifdef PLATFORM_FREEBSD
-	pbuf = malloc(sz, M_DEVBUF, M_ZERO | M_NOWAIT);
-#endif
 #ifdef PLATFORM_WINDOWS
 	NdisAllocateMemoryWithTag(&pbuf, sz, RT_TAG);
 	if (pbuf != NULL)
@@ -123,9 +117,6 @@ inline void _rtw_vmfree(void *pbuf, u32 sz)
 {
 #ifdef PLATFORM_LINUX
 	vfree(pbuf);
-#endif
-#ifdef PLATFORM_FREEBSD
-	free(pbuf, M_DEVBUF);
 #endif
 #ifdef PLATFORM_WINDOWS
 	NdisFreeMemory(pbuf, sz, 0);
@@ -152,9 +143,6 @@ void *_rtw_malloc(u32 sz)
 		pbuf = kmalloc(sz, in_interrupt() ? GFP_ATOMIC : GFP_KERNEL);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	pbuf = malloc(sz, M_DEVBUF, M_NOWAIT);
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisAllocateMemoryWithTag(&pbuf, sz, RT_TAG);
@@ -177,25 +165,18 @@ void *_rtw_malloc(u32 sz)
 
 void *_rtw_zmalloc(u32 sz)
 {
-#ifdef PLATFORM_FREEBSD
-	return malloc(sz, M_DEVBUF, M_ZERO | M_NOWAIT);
-#else /* PLATFORM_FREEBSD */
-	void *pbuf = _rtw_malloc(sz);
+       void *pbuf = _rtw_malloc(sz);
 
-	if (pbuf != NULL) {
-
+       if (pbuf != NULL) {
 #ifdef PLATFORM_LINUX
-		memset(pbuf, 0, sz);
+               memset(pbuf, 0, sz);
 #endif
-
 #ifdef PLATFORM_WINDOWS
-		NdisFillMemory(pbuf, sz, 0);
+               NdisFillMemory(pbuf, sz, 0);
 #endif
+       }
 
-	}
-
-	return pbuf;
-#endif /* PLATFORM_FREEBSD */
+       return pbuf;
 }
 
 void _rtw_mfree(void *pbuf, u32 sz)
@@ -209,9 +190,6 @@ void _rtw_mfree(void *pbuf, u32 sz)
 #endif
 		kfree(pbuf);
 
-#endif
-#ifdef PLATFORM_FREEBSD
-	free(pbuf, M_DEVBUF);
 #endif
 #ifdef PLATFORM_WINDOWS
 
@@ -228,52 +206,6 @@ void _rtw_mfree(void *pbuf, u32 sz)
 
 }
 
-#ifdef PLATFORM_FREEBSD
-/* review again */
-struct sk_buff *dev_alloc_skb(unsigned int size)
-{
-	struct sk_buff *skb = NULL;
-	u8 *data = NULL;
-
-	/* skb = _rtw_zmalloc(sizeof(struct sk_buff)); */ /* for skb->len, etc. */
-	skb = _rtw_malloc(sizeof(struct sk_buff));
-	if (!skb)
-		goto out;
-	data = _rtw_malloc(size);
-	if (!data)
-		goto nodata;
-
-	skb->head = (unsigned char *)data;
-	skb->data = (unsigned char *)data;
-	skb->tail = (unsigned char *)data;
-	skb->end = (unsigned char *)data + size;
-	skb->len = 0;
-	/* printf("%s()-%d: skb=%p, skb->head = %p\n", __FUNCTION__, __LINE__, skb, skb->head); */
-
-out:
-	return skb;
-nodata:
-	_rtw_mfree(skb, sizeof(struct sk_buff));
-	skb = NULL;
-	goto out;
-
-}
-
-void dev_kfree_skb_any(struct sk_buff *skb)
-{
-	/* printf("%s()-%d: skb->head = %p\n", __FUNCTION__, __LINE__, skb->head); */
-	if (skb->head)
-		_rtw_mfree(skb->head, 0);
-	/* printf("%s()-%d: skb = %p\n", __FUNCTION__, __LINE__, skb); */
-	if (skb)
-		_rtw_mfree(skb, 0);
-}
-struct sk_buff *skb_clone(const struct sk_buff *skb)
-{
-	return NULL;
-}
-
-#endif /* PLATFORM_FREEBSD */
 
 inline struct sk_buff *_rtw_skb_alloc(u32 sz)
 {
@@ -281,9 +213,6 @@ inline struct sk_buff *_rtw_skb_alloc(u32 sz)
 	return __dev_alloc_skb(sz, in_interrupt() ? GFP_ATOMIC : GFP_KERNEL);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	return dev_alloc_skb(sz);
-#endif /* PLATFORM_FREEBSD */
 }
 
 inline void _rtw_skb_free(struct sk_buff *skb)
@@ -297,9 +226,6 @@ inline struct sk_buff *_rtw_skb_copy(const struct sk_buff *skb)
 	return skb_copy(skb, in_interrupt() ? GFP_ATOMIC : GFP_KERNEL);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	return NULL;
-#endif /* PLATFORM_FREEBSD */
 }
 
 inline struct sk_buff *_rtw_skb_clone(struct sk_buff *skb)
@@ -308,9 +234,6 @@ inline struct sk_buff *_rtw_skb_clone(struct sk_buff *skb)
 	return skb_clone(skb, in_interrupt() ? GFP_ATOMIC : GFP_KERNEL);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	return skb_clone(skb);
-#endif /* PLATFORM_FREEBSD */
 }
 inline struct sk_buff *_rtw_pskb_copy(struct sk_buff *skb)
 {
@@ -318,9 +241,6 @@ inline struct sk_buff *_rtw_pskb_copy(struct sk_buff *skb)
         return pskb_copy(skb, in_interrupt() ? GFP_ATOMIC : GFP_KERNEL);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	return NULL;
-#endif /* PLATFORM_FREEBSD */
 }
 
 inline int _rtw_netif_rx(_nic_hdl ndev, struct sk_buff *skb)
@@ -328,11 +248,9 @@ inline int _rtw_netif_rx(_nic_hdl ndev, struct sk_buff *skb)
 #if defined(PLATFORM_LINUX)
 	skb->dev = ndev;
 	return netif_rx(skb);
-#elif defined(PLATFORM_FREEBSD)
-	return (*ndev->if_input)(ndev, skb);
 #else
-	rtw_warn_on(1);
-	return -1;
+       rtw_warn_on(1);
+       return -1;
 #endif
 }
 
@@ -376,9 +294,6 @@ inline void *_rtw_usb_buffer_alloc(struct usb_device *dev, size_t size, dma_addr
         return usb_alloc_coherent(dev, size, (in_interrupt() ? GFP_ATOMIC : GFP_KERNEL), dma);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	return malloc(size, M_USBDEV, M_NOWAIT | M_ZERO);
-#endif /* PLATFORM_FREEBSD */
 }
 inline void _rtw_usb_buffer_free(struct usb_device *dev, size_t size, void *addr, dma_addr_t dma)
 {
@@ -386,9 +301,6 @@ inline void _rtw_usb_buffer_free(struct usb_device *dev, size_t size, void *addr
         usb_free_coherent(dev, size, addr, dma);
 #endif /* PLATFORM_LINUX */
 
-#ifdef PLATFORM_FREEBSD
-	free(addr, M_USBDEV);
-#endif /* PLATFORM_FREEBSD */
 }
 #endif /* CONFIG_USB_HCI */
 
@@ -869,51 +781,43 @@ void rtw_mfree2d(void *pbuf, int h, int w, int size)
 inline void rtw_os_pkt_free(_pkt *pkt)
 {
 #if defined(PLATFORM_LINUX)
-	rtw_skb_free(pkt);
-#elif defined(PLATFORM_FREEBSD)
-	m_freem(pkt);
+       rtw_skb_free(pkt);
 #else
-	#error "TBD\n"
+       #error "TBD\n"
 #endif
 }
 
 inline _pkt *rtw_os_pkt_copy(_pkt *pkt)
 {
 #if defined(PLATFORM_LINUX)
-	return rtw_skb_copy(pkt);
-#elif defined(PLATFORM_FREEBSD)
-	return m_dup(pkt, M_NOWAIT);
+       return rtw_skb_copy(pkt);
 #else
-	#error "TBD\n"
+       #error "TBD\n"
 #endif
 }
 
 inline void *rtw_os_pkt_data(_pkt *pkt)
 {
 #if defined(PLATFORM_LINUX)
-	return pkt->data;
-#elif defined(PLATFORM_FREEBSD)
-	return pkt->m_data;
+       return pkt->data;
 #else
-	#error "TBD\n"
+       #error "TBD\n"
 #endif
 }
 
 inline u32 rtw_os_pkt_len(_pkt *pkt)
 {
 #if defined(PLATFORM_LINUX)
-	return pkt->len;
-#elif defined(PLATFORM_FREEBSD)
-	return pkt->m_pkthdr.len;
+       return pkt->len;
 #else
-	#error "TBD\n"
+       #error "TBD\n"
 #endif
 }
 
 void _rtw_memcpy(void *dst, const void *src, u32 sz)
 {
 
-#if defined(PLATFORM_LINUX) || defined (PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX)
 
 	memcpy(dst, src, sz);
 
@@ -939,7 +843,7 @@ inline void _rtw_memmove(void *dst, const void *src, u32 sz)
 int	_rtw_memcmp(const void *dst, const void *src, u32 sz)
 {
 
-#if defined(PLATFORM_LINUX) || defined (PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX)
 	/* under Linux/GNU/GLibc, the return value of memcmp for two same mem. chunk is 0 */
 
 	if (!(memcmp(dst, src, sz)))
@@ -966,7 +870,7 @@ int	_rtw_memcmp(const void *dst, const void *src, u32 sz)
 void _rtw_memset(void *pbuf, int c, u32 sz)
 {
 
-#if defined(PLATFORM_LINUX) || defined (PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX)
 
 	memset(pbuf, c, sz);
 
@@ -984,15 +888,6 @@ void _rtw_memset(void *pbuf, int c, u32 sz)
 
 }
 
-#ifdef PLATFORM_FREEBSD
-static inline void __list_add(_list *pnew, _list *pprev, _list *pnext)
-{
-	pnext->prev = pnew;
-	pnew->next = pnext;
-	pnew->prev = pprev;
-	pprev->next = pnew;
-}
-#endif /* PLATFORM_FREEBSD */
 
 
 void _rtw_init_listhead(_list *list)
@@ -1004,10 +899,6 @@ void _rtw_init_listhead(_list *list)
 
 #endif
 
-#ifdef PLATFORM_FREEBSD
-	list->next = list;
-	list->prev = list;
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisInitializeListHead(list);
@@ -1028,14 +919,6 @@ u32	rtw_is_list_empty(_list *phead)
 #ifdef PLATFORM_LINUX
 
 	if (list_empty(phead))
-		return _TRUE;
-	else
-		return _FALSE;
-
-#endif
-#ifdef PLATFORM_FREEBSD
-
-	if (phead->next == phead)
 		return _TRUE;
 	else
 		return _FALSE;
@@ -1062,9 +945,6 @@ void rtw_list_insert_head(_list *plist, _list *phead)
 	list_add(plist, phead);
 #endif
 
-#ifdef PLATFORM_FREEBSD
-	__list_add(plist, phead, phead->next);
-#endif
 
 #ifdef PLATFORM_WINDOWS
 	InsertHeadList(phead, plist);
@@ -1077,11 +957,6 @@ void rtw_list_insert_tail(_list *plist, _list *phead)
 #ifdef PLATFORM_LINUX
 
 	list_add_tail(plist, phead);
-
-#endif
-#ifdef PLATFORM_FREEBSD
-
-	__list_add(plist, phead->prev, phead);
 
 #endif
 #ifdef PLATFORM_WINDOWS
@@ -1171,9 +1046,6 @@ void rtw_init_timer(_timer *ptimer, void *padapter, void *pfunc, void *ctx)
 #ifdef PLATFORM_LINUX
 	_init_timer(ptimer, adapter->pnetdev, pfunc, ctx);
 #endif
-#ifdef PLATFORM_FREEBSD
-	_init_timer(ptimer, adapter->pifp, pfunc, ctx);
-#endif
 #ifdef PLATFORM_WINDOWS
 	_init_timer(ptimer, adapter->hndis_adapter, pfunc, ctx);
 #endif
@@ -1194,9 +1066,6 @@ void _rtw_init_sema(_sema	*sema, int init_val)
 	sema_init(sema, init_val);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	sema_init(sema, init_val, "rtw_drv");
-#endif
 #ifdef PLATFORM_OS_XP
 
 	KeInitializeSemaphore(sema, init_val,  SEMA_UPBND); /* count=0; */
@@ -1212,9 +1081,6 @@ void _rtw_init_sema(_sema	*sema, int init_val)
 
 void _rtw_free_sema(_sema	*sema)
 {
-#ifdef PLATFORM_FREEBSD
-	sema_destroy(sema);
-#endif
 #ifdef PLATFORM_OS_CE
 	CloseHandle(*sema);
 #endif
@@ -1228,9 +1094,6 @@ void _rtw_up_sema(_sema	*sema)
 
 	up(sema);
 
-#endif
-#ifdef PLATFORM_FREEBSD
-	sema_post(sema);
 #endif
 #ifdef PLATFORM_OS_XP
 
@@ -1254,10 +1117,6 @@ u32 _rtw_down_sema(_sema *sema)
 		return _SUCCESS;
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	sema_wait(sema);
-	return  _SUCCESS;
-#endif
 #ifdef PLATFORM_OS_XP
 
 	if (STATUS_SUCCESS == KeWaitForSingleObject(sema, Executive, KernelMode, TRUE, NULL))
@@ -1280,9 +1139,6 @@ inline void thread_exit(_completion *comp)
 	complete_and_exit(comp, 0);
 #endif
 
-#ifdef PLATFORM_FREEBSD
-	printf("%s", "RTKTHREAD_exit");
-#endif
 
 #ifdef PLATFORM_OS_CE
 	ExitThread(STATUS_SUCCESS);
@@ -1317,9 +1173,6 @@ void	_rtw_mutex_init(_mutex *pmutex)
 #ifdef PLATFORM_LINUX
         mutex_init(pmutex);
 #endif
-#ifdef PLATFORM_FREEBSD
-	mtx_init(pmutex, "", NULL, MTX_DEF | MTX_RECURSE);
-#endif
 #ifdef PLATFORM_OS_XP
 
 	KeInitializeMutex(pmutex, 0);
@@ -1336,9 +1189,6 @@ void	_rtw_mutex_free(_mutex *pmutex)
 {
 #ifdef PLATFORM_LINUX
         mutex_destroy(pmutex);
-#ifdef PLATFORM_FREEBSD
-        sema_destroy(pmutex);
-#endif
 
 #endif
 
@@ -1359,9 +1209,6 @@ void	_rtw_spinlock_init(_lock *plock)
 	spin_lock_init(plock);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	mtx_init(plock, "", NULL, MTX_DEF | MTX_RECURSE);
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisAllocateSpinLock(plock);
@@ -1372,9 +1219,6 @@ void	_rtw_spinlock_init(_lock *plock)
 
 void	_rtw_spinlock_free(_lock *plock)
 {
-#ifdef PLATFORM_FREEBSD
-	mtx_destroy(plock);
-#endif
 
 #ifdef PLATFORM_WINDOWS
 
@@ -1383,25 +1227,6 @@ void	_rtw_spinlock_free(_lock *plock)
 #endif
 
 }
-#ifdef PLATFORM_FREEBSD
-extern PADAPTER prtw_lock;
-
-void rtw_mtx_lock(_lock *plock)
-{
-	if (prtw_lock)
-		mtx_lock(&prtw_lock->glock);
-	else
-		printf("%s prtw_lock==NULL", __FUNCTION__);
-}
-void rtw_mtx_unlock(_lock *plock)
-{
-	if (prtw_lock)
-		mtx_unlock(&prtw_lock->glock);
-	else
-		printf("%s prtw_lock==NULL", __FUNCTION__);
-
-}
-#endif /* PLATFORM_FREEBSD */
 
 
 void	_rtw_spinlock(_lock	*plock)
@@ -1411,9 +1236,6 @@ void	_rtw_spinlock(_lock	*plock)
 
 	spin_lock(plock);
 
-#endif
-#ifdef PLATFORM_FREEBSD
-	mtx_lock(plock);
 #endif
 #ifdef PLATFORM_WINDOWS
 
@@ -1431,9 +1253,6 @@ void	_rtw_spinunlock(_lock *plock)
 	spin_unlock(plock);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	mtx_unlock(plock);
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisReleaseSpinLock(plock);
@@ -1450,9 +1269,6 @@ void	_rtw_spinlock_ex(_lock	*plock)
 	spin_lock(plock);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	mtx_lock(plock);
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisDprAcquireSpinLock(plock);
@@ -1468,9 +1284,6 @@ void	_rtw_spinunlock_ex(_lock *plock)
 
 	spin_unlock(plock);
 
-#endif
-#ifdef PLATFORM_FREEBSD
-	mtx_unlock(plock);
 #endif
 #ifdef PLATFORM_WINDOWS
 
@@ -1513,11 +1326,6 @@ systime _rtw_get_current_time(void)
 #ifdef PLATFORM_LINUX
 	return jiffies;
 #endif
-#ifdef PLATFORM_FREEBSD
-	struct timeval tvp;
-	getmicrotime(&tvp);
-	return tvp.tv_sec;
-#endif
 #ifdef PLATFORM_WINDOWS
 	LARGE_INTEGER	SystemTime;
 	NdisGetCurrentSystemTime(&SystemTime);
@@ -1530,9 +1338,6 @@ inline u32 _rtw_systime_to_ms(systime stime)
 #ifdef PLATFORM_LINUX
 	return jiffies_to_msecs(stime);
 #endif
-#ifdef PLATFORM_FREEBSD
-	return stime * 1000;
-#endif
 #ifdef PLATFORM_WINDOWS
 	return stime / 10000 ;
 #endif
@@ -1542,9 +1347,6 @@ inline systime _rtw_ms_to_systime(u32 ms)
 {
 #ifdef PLATFORM_LINUX
 	return msecs_to_jiffies(ms);
-#endif
-#ifdef PLATFORM_FREEBSD
-	return ms / 1000;
 #endif
 #ifdef PLATFORM_WINDOWS
 	return ms * 10000 ;
@@ -1602,10 +1404,6 @@ void rtw_sleep_schedulable(int ms)
 	return;
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	DELAY(ms * 1000);
-	return ;
-#endif
 
 #ifdef PLATFORM_WINDOWS
 
@@ -1627,11 +1425,6 @@ void rtw_msleep_os(int ms)
                 msleep((unsigned int)ms);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	/* Delay for delay microseconds */
-	DELAY(ms * 1000);
-	return ;
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisMSleep(ms * 1000); /* (us)*1000=(ms) */
@@ -1646,12 +1439,6 @@ void rtw_usleep_os(int us)
         usleep_range(us, us + 1);
 #endif
 
-#ifdef PLATFORM_FREEBSD
-	/* Delay for delay microseconds */
-	DELAY(us);
-
-	return ;
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisMSleep(us); /* (us) */
@@ -1722,10 +1509,6 @@ void rtw_mdelay_os(int ms)
 	mdelay((unsigned long)ms);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	DELAY(ms * 1000);
-	return ;
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisStallExecution(ms * 1000); /* (us)*1000=(ms) */
@@ -1742,11 +1525,6 @@ void rtw_udelay_os(int us)
 	udelay((unsigned long)us);
 
 #endif
-#ifdef PLATFORM_FREEBSD
-	/* Delay for delay microseconds */
-	DELAY(us);
-	return ;
-#endif
 #ifdef PLATFORM_WINDOWS
 
 	NdisStallExecution(us); /* (us) */
@@ -1759,9 +1537,6 @@ void rtw_udelay_os(int us)
 void rtw_yield_os(void)
 {
 #ifdef PLATFORM_LINUX
-	yield();
-#endif
-#ifdef PLATFORM_FREEBSD
 	yield();
 #endif
 #ifdef PLATFORM_WINDOWS
@@ -1933,8 +1708,6 @@ inline void ATOMIC_SET(ATOMIC_T *v, int i)
 	atomic_set(v, i);
 #elif defined(PLATFORM_WINDOWS)
 	*v = i; /* other choice???? */
-#elif defined(PLATFORM_FREEBSD)
-	atomic_set_int(v, i);
 #endif
 }
 
@@ -1944,8 +1717,6 @@ inline int ATOMIC_READ(ATOMIC_T *v)
 	return atomic_read(v);
 #elif defined(PLATFORM_WINDOWS)
 	return *v; /* other choice???? */
-#elif defined(PLATFORM_FREEBSD)
-	return atomic_load_acq_32(v);
 #endif
 }
 
@@ -1955,8 +1726,6 @@ inline void ATOMIC_ADD(ATOMIC_T *v, int i)
 	atomic_add(i, v);
 #elif defined(PLATFORM_WINDOWS)
 	InterlockedAdd(v, i);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_add_int(v, i);
 #endif
 }
 inline void ATOMIC_SUB(ATOMIC_T *v, int i)
@@ -1965,8 +1734,6 @@ inline void ATOMIC_SUB(ATOMIC_T *v, int i)
 	atomic_sub(i, v);
 #elif defined(PLATFORM_WINDOWS)
 	InterlockedAdd(v, -i);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_subtract_int(v, i);
 #endif
 }
 
@@ -1976,8 +1743,6 @@ inline void ATOMIC_INC(ATOMIC_T *v)
 	atomic_inc(v);
 #elif defined(PLATFORM_WINDOWS)
 	InterlockedIncrement(v);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_add_int(v, 1);
 #endif
 }
 
@@ -1987,8 +1752,6 @@ inline void ATOMIC_DEC(ATOMIC_T *v)
 	atomic_dec(v);
 #elif defined(PLATFORM_WINDOWS)
 	InterlockedDecrement(v);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_subtract_int(v, 1);
 #endif
 }
 
@@ -1998,9 +1761,6 @@ inline int ATOMIC_ADD_RETURN(ATOMIC_T *v, int i)
 	return atomic_add_return(i, v);
 #elif defined(PLATFORM_WINDOWS)
 	return InterlockedAdd(v, i);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_add_int(v, i);
-	return atomic_load_acq_32(v);
 #endif
 }
 
@@ -2010,9 +1770,6 @@ inline int ATOMIC_SUB_RETURN(ATOMIC_T *v, int i)
 	return atomic_sub_return(i, v);
 #elif defined(PLATFORM_WINDOWS)
 	return InterlockedAdd(v, -i);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_subtract_int(v, i);
-	return atomic_load_acq_32(v);
 #endif
 }
 
@@ -2022,9 +1779,6 @@ inline int ATOMIC_INC_RETURN(ATOMIC_T *v)
 	return atomic_inc_return(v);
 #elif defined(PLATFORM_WINDOWS)
 	return InterlockedIncrement(v);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_add_int(v, 1);
-	return atomic_load_acq_32(v);
 #endif
 }
 
@@ -2034,9 +1788,6 @@ inline int ATOMIC_DEC_RETURN(ATOMIC_T *v)
 	return atomic_dec_return(v);
 #elif defined(PLATFORM_WINDOWS)
 	return InterlockedDecrement(v);
-#elif defined(PLATFORM_FREEBSD)
-	atomic_subtract_int(v, 1);
-	return atomic_load_acq_32(v);
 #endif
 }
 
@@ -2409,75 +2160,6 @@ error:
 }
 #endif
 
-#ifdef PLATFORM_FREEBSD
-/*
- * Copy a buffer from userspace and write into kernel address
- * space.
- *
- * This emulation just calls the FreeBSD copyin function (to
- * copy data from user space buffer into a kernel space buffer)
- * and is designed to be used with the above io_write_wrapper.
- *
- * This function should return the number of bytes not copied.
- * I.e. success results in a zero value.
- * Negative error values are not returned.
- */
-unsigned long
-copy_from_user(void *to, const void *from, unsigned long n)
-{
-	if (copyin(from, to, n) != 0) {
-		/* Any errors will be treated as a failure
-		   to copy any of the requested bytes */
-		return n;
-	}
-
-	return 0;
-}
-
-unsigned long
-copy_to_user(void *to, const void *from, unsigned long n)
-{
-	if (copyout(from, to, n) != 0) {
-		/* Any errors will be treated as a failure
-		   to copy any of the requested bytes */
-		return n;
-	}
-
-	return 0;
-}
-
-
-/*
- * The usb_register and usb_deregister functions are used to register
- * usb drivers with the usb subsystem. In this compatibility layer
- * emulation a list of drivers (struct usb_driver) is maintained
- * and is used for probing/attaching etc.
- *
- * usb_register and usb_deregister simply call these functions.
- */
-int
-usb_register(struct usb_driver *driver)
-{
-	rtw_usb_linux_register(driver);
-	return 0;
-}
-
-
-int
-usb_deregister(struct usb_driver *driver)
-{
-	rtw_usb_linux_deregister(driver);
-	return 0;
-}
-
-void module_init_exit_wrapper(void *arg)
-{
-	int (*func)(void) = arg;
-	func();
-	return;
-}
-
-#endif /* PLATFORM_FREEBSD */
 
 #ifdef CONFIG_PLATFORM_SPRD
 	#ifdef do_div
@@ -2492,8 +2174,6 @@ u64 rtw_modular64(u64 x, u64 y)
 	return do_div(x, y);
 #elif defined(PLATFORM_WINDOWS)
 	return x % y;
-#elif defined(PLATFORM_FREEBSD)
-	return x % y;
 #endif
 }
 
@@ -2504,8 +2184,6 @@ u64 rtw_division64(u64 x, u64 y)
 	return x;
 #elif defined(PLATFORM_WINDOWS)
 	return x / y;
-#elif defined(PLATFORM_FREEBSD)
-	return x / y;
 #endif
 }
 
@@ -2514,8 +2192,6 @@ inline u32 rtw_random32(void)
 #ifdef PLATFORM_LINUX
         return prandom_u32();
 #elif defined(PLATFORM_WINDOWS)
-#error "to be implemented\n"
-#elif defined(PLATFORM_FREEBSD)
 #error "to be implemented\n"
 #endif
 }


### PR DESCRIPTION
## Summary
- remove FreeBSD conditional branches from osdep_service.c
- keep Linux implementations intact

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef68e1808331878126f115c13505