### PR TITLE
include: Drop FreeBSD from rtw_recv.h conditional

### DIFF
--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -525,7 +525,7 @@ struct recv_buf {
 
 #ifdef CONFIG_USB_HCI
 
-#if defined(PLATFORM_OS_XP) || defined(PLATFORM_LINUX) || defined(PLATFORM_FREEBSD)
+#if defined(PLATFORM_OS_XP) || defined(PLATFORM_LINUX)
 	PURB	purb;
 	dma_addr_t dma_transfer_addr;	/* (in) dma addr for transfer_buffer */
 	u32 alloc_sz;


### PR DESCRIPTION
## Summary
- remove FreeBSD from USB_HCI conditional in `rtw_recv.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b6a0058883319bf536b82ea45d8f