### PR TITLE
include: Strip FreeBSD checks from generic byteorder

### DIFF
--- a/include/byteorder/generic.h
+++ b/include/byteorder/generic.h
@@ -93,7 +93,7 @@
  */
 
 
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_WINDOWS) || defined(PLATFORM_MPIXEL) || defined(PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_WINDOWS) || defined(PLATFORM_MPIXEL)
 	/*
 	* inside the kernel, we can use nicknames;
 	* outside of it, we must avoid POSIX namespace pollution...
@@ -164,15 +164,11 @@
 	extern __u32			ntohl(__u32);
 	extern __u32			htonl(__u32);
 #else /* defined(PLATFORM_LINUX) || (defined (__GLIBC__) && __GLIBC__ >= 2) */
-	#ifndef PLATFORM_FREEBSD
 		extern unsigned long int	ntohl(unsigned long int);
 		extern unsigned long int	htonl(unsigned long int);
-	#endif
 #endif
-#ifndef PLATFORM_FREEBSD
 	extern unsigned short int	ntohs(unsigned short int);
 	extern unsigned short int	htons(unsigned short int);
-#endif
 
 #if defined(__GNUC__) && (__GNUC__ >= 2) && defined(__OPTIMIZE__) || defined(PLATFORM_MPIXEL)
 


### PR DESCRIPTION
## Summary
- remove FreeBSD clause from platform checks
- drop FreeBSD-specific guards around function prototypes

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846baae7c708331a2bf46136b908607