### PR TITLE
include: Purge PLATFORM_FREEBSD from osdep_service.h

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -37,9 +37,6 @@
 #define _FALSE		0
 
 
-#ifdef PLATFORM_FREEBSD
-	#include <osdep_service_bsd.h>
-#endif
 
 #ifdef PLATFORM_LINUX
        #include <linux/version.h>
@@ -306,9 +303,7 @@ void rtw_list_splice(_list *list, _list *head);
 void rtw_list_splice_init(_list *list, _list *head);
 void rtw_list_splice_tail(_list *list, _list *head);
 
-#ifndef PLATFORM_FREEBSD
 extern void	rtw_list_delete(_list *plist);
-#endif /* PLATFORM_FREEBSD */
 
 void rtw_hlist_head_init(rtw_hlist_head *h);
 void rtw_hlist_add_head(rtw_hlist_node *n, rtw_hlist_head *h);
@@ -322,9 +317,7 @@ extern void	_rtw_up_sema(_sema	*sema);
 extern u32	_rtw_down_sema(_sema *sema);
 extern void	_rtw_mutex_init(_mutex *pmutex);
 extern void	_rtw_mutex_free(_mutex *pmutex);
-#ifndef PLATFORM_FREEBSD
 extern void	_rtw_spinlock_init(_lock *plock);
-#endif /* PLATFORM_FREEBSD */
 extern void	_rtw_spinlock_free(_lock *plock);
 extern void	_rtw_spinlock(_lock	*plock);
 extern void	_rtw_spinunlock(_lock	*plock);
@@ -402,10 +395,7 @@ __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 static __inline void thread_enter(char *name)
 {
 #ifdef PLATFORM_LINUX
-	allow_signal(SIGTERM);
-#endif
-#ifdef PLATFORM_FREEBSD
-	printf("%s", "RTKTHREAD_enter");
+        allow_signal(SIGTERM);
 #endif
 }
 void thread_exit(_completion *comp);
@@ -447,7 +437,7 @@ __inline static void flush_signals_thread(void)
 __inline static _OS_STATUS res_to_status(sint res)
 {
 
-#if defined(PLATFORM_LINUX) || defined (PLATFORM_MPIXEL) || defined (PLATFORM_FREEBSD)
+#if defined(PLATFORM_LINUX) || defined (PLATFORM_MPIXEL)
 	return res;
 #endif
 
@@ -628,9 +618,7 @@ extern int rtw_retrieve_from_file(const char *path, u8 *buf, u32 sz);
 extern int rtw_store_to_file(const char *path, u8 *buf, u32 sz);
 
 
-#ifndef PLATFORM_FREEBSD
 extern void rtw_free_netdev(struct net_device *netdev);
-#endif /* PLATFORM_FREEBSD */
 
 
 extern u64 rtw_modular64(u64 x, u64 y);


### PR DESCRIPTION
## Summary
- drop FreeBSD specific include and wrappers
- clean up thread helper and status conversion

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2d518fc833185160bca0824e3ce