### PR TITLE
Remove unused Windows typedefs

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -31,43 +31,6 @@
 	#define _FALSE	FALSE
 #endif
 
-#ifdef PLATFORM_WINDOWS
-
-	typedef signed char s8;
-	typedef unsigned char u8;
-
-	typedef signed short s16;
-	typedef unsigned short u16;
-
-	typedef signed long s32;
-	typedef unsigned long u32;
-
-	typedef unsigned int	uint;
-	typedef	signed int		sint;
-
-
-	typedef signed long long s64;
-	typedef unsigned long long u64;
-
-	#ifdef NDIS50_MINIPORT
-
-		#define NDIS_MAJOR_VERSION       5
-		#define NDIS_MINOR_VERSION       0
-
-	#endif
-
-	#ifdef NDIS51_MINIPORT
-
-		#define NDIS_MAJOR_VERSION       5
-		#define NDIS_MINOR_VERSION       1
-
-	#endif
-
-	typedef NDIS_PROC proc_t;
-
-	typedef LONG atomic_t;
-
-#endif
 
 #ifdef PLATFORM_LINUX
 	#include <linux/version.h>


### PR DESCRIPTION
## Summary
- clean up `include/basic_types.h` by dropping the `PLATFORM_WINDOWS` typedef block

## Testing
- `apt-get install -y build-essential flex bison bc wget tar xz-utils gcc-aarch64-linux-gnu libssl-dev libelf-dev`
- `./tests/test_kernel_5.4.sh` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684734698a6c8331a69e67db5170233b