### PR TITLE
include: Drop PLATFORM_WINDOWS check

### DIFF
--- a/include/byteorder/swab.h
+++ b/include/byteorder/swab.h
@@ -114,7 +114,7 @@ __inline static __u32 __fswab32(__u32 x)
         return __arch__swab32(x);
 }
 
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_WINDOWS)
+#ifdef PLATFORM_LINUX
 	#define swab16 __swab16
 	#define swab32 __swab32
 	#define swab64 __swab64


### PR DESCRIPTION
## Summary
- remove PLATFORM_WINDOWS check from swab macros

## Testing
- `sudo apt-get install -y build-essential flex bison bc wget tar xz-utils gcc-aarch64-linux-gnu libssl-dev libelf-dev`
- `./tests/test_kernel_5.4.sh` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684736761774833198cdf8340729a716