### PR TITLE
Remove Windows path in btc headers

### DIFF
--- a/hal/btc/mp_precomp.h
+++ b/hal/btc/mp_precomp.h
@@ -23,8 +23,6 @@
 #ifdef PLATFORM_LINUX
 #define rsprintf snprintf
 #define rstrncat(dst, src, src_size) strncat(dst, src, src_size)
-#elif defined(PLATFORM_WINDOWS)
-#define rsprintf sprintf_s
 #endif
 
 #define DCMD_Printf			DBG_BT_INFO


### PR DESCRIPTION
## Summary
- drop obsolete Windows configuration in `mp_precomp.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: scripts/Makefile.ubsan missing)*

------
https://chatgpt.com/codex/tasks/task_e_68473e7eb4248331959042d4abd89930