### PR TITLE
include: remove obsolete OS headers

### DIFF
--- a/include/custom_gpio.h
+++ b/include/custom_gpio.h
@@ -18,13 +18,6 @@
 #include <drv_conf.h>
 #include <osdep_service.h>
 
-#ifdef PLATFORM_OS_XP
-	#include <drv_types_xp.h>
-#endif
-
-#ifdef PLATFORM_OS_CE
-	#include <drv_types_ce.h>
-#endif
 
 #ifdef PLATFORM_LINUX
 	#include <drv_types_linux.h>


### PR DESCRIPTION
## Summary
- strip XP and CE includes from `custom_gpio.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68474161cc488331a3b17963fba25d54