### PR TITLE
Remove obsolete check

### DIFF
--- a/include/drv_conf.h
+++ b/include/drv_conf.h
@@ -16,11 +16,6 @@
 #define __DRV_CONF_H__
 #include "autoconf.h"
 #include "hal_ic_cfg.h"
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-
-	#error "Shall be Linux or Windows, but not both!\n"
-
-#endif
 #define CONFIG_RSSI_PRIORITY
 #ifdef CONFIG_RTW_REPEATER_SON
 	#ifndef CONFIG_AP


### PR DESCRIPTION
## Summary
- remove legacy PLATFORM_LINUX/PLATFORM_WINDOWS check in `drv_conf.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6847416bc0748331bf5e9be7927abb66