### PR TITLE
Remove XP and CE sections from SDIO header

### DIFF
--- a/include/drv_types_sdio.h
+++ b/include/drv_types_sdio.h
@@ -28,14 +28,7 @@
 	#endif /* CONFIG_PLATFORM_SPRD */
 #endif
 
-#ifdef PLATFORM_OS_XP
-	#include <wdm.h>
-	#include <ntddsd.h>
-#endif
 
-#ifdef PLATFORM_OS_CE
-	#include <sdcardddk.h>
-#endif
 
 #define RTW_SDIO_CLK_33M	33000000
 #define RTW_SDIO_CLK_40M	40000000
@@ -57,22 +50,7 @@ typedef struct sdio_data {
 	u8	sd3_bus_mode;
 #endif
 
-#ifdef PLATFORM_OS_XP
-	PDEVICE_OBJECT				pphysdevobj;
-	PDEVICE_OBJECT				pfuncdevobj;
-	PDEVICE_OBJECT				pnextdevobj;
-	SDBUS_INTERFACE_STANDARD	sdbusinft;
-	u8							nextdevstacksz;
-#endif
 
-#ifdef PLATFORM_OS_CE
-	SD_DEVICE_HANDLE			hDevice;
-	SD_CARD_RCA					sd_rca;
-	SD_CARD_INTERFACE			card_intf;
-	BOOLEAN						enableIsarWithStatus;
-	WCHAR						active_path[MAX_ACTIVE_REG_PATH];
-	SD_HOST_BLOCK_CAPABILITY	sd_host_blk_cap;
-#endif
 } SDIO_DATA, *PSDIO_DATA;
 
 #define dvobj_to_sdio_func(d)	((d)->intf_data.func)


### PR DESCRIPTION
## Summary
- clean up `drv_types_sdio.h` by dropping sections for unsupported platforms
- install required build packages
- compile the driver with the kernel 5.4 test script

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684741749838833198e9b0df35f8aeeb