### PR TITLE
Remove OS_CE block from gspi header

### DIFF
--- a/include/gspi_osintf.h
+++ b/include/gspi_osintf.h
@@ -16,10 +16,5 @@
 #define __SDIO_OSINTF_H__
 
 
-#ifdef PLATFORM_OS_CE
-	extern NDIS_STATUS ce_sd_get_dev_hdl(PADAPTER padapter);
-	SD_API_STATUS ce_sd_int_callback(SD_DEVICE_HANDLE hDevice, PADAPTER padapter);
-	extern void sd_setup_irs(PADAPTER padapter);
-#endif
 
 #endif


### PR DESCRIPTION
## Summary
- drop obsolete `PLATFORM_OS_CE` code from `gspi_osintf.h`

## Testing
- `./tests/test_kernel_5.4.sh` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68474177f99c833184a1114ed510f39a