### PR TITLE
Remove obsolete platform code

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -45,13 +45,6 @@
        #include <osdep_service_linux.h>
 #endif
 
-#ifdef PLATFORM_OS_XP
-	#include <osdep_service_xp.h>
-#endif
-
-#ifdef PLATFORM_OS_CE
-	#include <osdep_service_ce.h>
-#endif
 
 /* #include <rtw_byteorder.h> */
 
@@ -441,14 +434,6 @@ __inline static _OS_STATUS res_to_status(sint res)
 	return res;
 #endif
 
-#ifdef PLATFORM_WINDOWS
-
-	if (res == _SUCCESS)
-		return NDIS_STATUS_SUCCESS;
-	else
-		return NDIS_STATUS_FAILURE;
-
-#endif
 
 }
 
@@ -469,15 +454,6 @@ __inline static int rtw_bug_check(void *parg1, void *parg2, void *parg3, void *p
 {
 	int ret = _TRUE;
 
-#ifdef PLATFORM_WINDOWS
-	if (((uint)parg1) <= 0x7fffffff ||
-	    ((uint)parg2) <= 0x7fffffff ||
-	    ((uint)parg3) <= 0x7fffffff ||
-	    ((uint)parg4) <= 0x7fffffff) {
-		ret = _FALSE;
-		KeBugCheckEx(0x87110000, (ULONG_PTR)parg1, (ULONG_PTR)parg2, (ULONG_PTR)parg3, (ULONG_PTR)parg4);
-	}
-#endif
 
 	return ret;
 


### PR DESCRIPTION
## Summary
- remove support branches for PLATFORM_OS_XP and PLATFORM_OS_CE
- drop Windows-specific sections from osdep service

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684746ab375c8331a8e08660f7154fac