### PR TITLE
Fix header macros

### DIFF
--- a/include/rtl8192e_recv.h
+++ b/include/rtl8192e_recv.h
@@ -18,11 +18,8 @@
 #if defined(CONFIG_USB_HCI)
 
 	#ifndef MAX_RECVBUF_SZ
-		#ifdef PLATFORM_OS_CE
-			#define MAX_RECVBUF_SZ (8192+1024) /* 8K+1k */
-		#else
-			#ifdef CONFIG_MINIMAL_MEMORY_USAGE
-				#define MAX_RECVBUF_SZ (4000) /* about 4K */
+                       #ifdef CONFIG_MINIMAL_MEMORY_USAGE
+                               #define MAX_RECVBUF_SZ (4000) /* about 4K */
 			#else
 				#ifdef CONFIG_PREALLOC_RX_SKB_BUFFER
 					#define MAX_RECVBUF_SZ (rtw_rtkm_get_buff_size()) /*depend rtkm*/
@@ -38,10 +35,9 @@
 				#ifdef CONFIG_PLATFORM_NOVATEK_NT72668
 					#undef MAX_RECVBUF_SZ
 					#define MAX_RECVBUF_SZ (15360) /* 15k < 16k */
-				#endif /* CONFIG_PLATFORM_NOVATEK_NT72668 */
-			#endif
-		#endif
-	#endif /* !MAX_RECVBUF_SZ */
+                                #endif /* CONFIG_PLATFORM_NOVATEK_NT72668 */
+                        #endif
+        #endif /* !MAX_RECVBUF_SZ */
 
 #elif defined(CONFIG_PCI_HCI)
 	/* #ifndef CONFIG_MINIMAL_MEMORY_USAGE */


### PR DESCRIPTION
## Summary
- remove PLATFORM_OS_CE branch from rtl8192e_recv.h
- fix header guard imbalance after cleanup

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68474b9dde788331aa801019c6b8fa22