### PR TITLE
Remove unused OS CE block

### DIFF
--- a/include/rtl8703b_recv.h
+++ b/include/rtl8703b_recv.h
@@ -21,25 +21,21 @@
 
 #if defined(CONFIG_USB_HCI)
 
-	#ifndef MAX_RECVBUF_SZ
-		#ifdef PLATFORM_OS_CE
-			#define MAX_RECVBUF_SZ (8192+1024) /* 8K+1k */
-		#else
-			#ifndef CONFIG_MINIMAL_MEMORY_USAGE
-				/* #define MAX_RECVBUF_SZ (32768) */ /* 32k */
-				/* #define MAX_RECVBUF_SZ (16384) */ /* 16K */
-				/* #define MAX_RECVBUF_SZ (10240) */ /* 10K */
-				#ifdef CONFIG_PLATFORM_MSTAR
-					#define MAX_RECVBUF_SZ (8192) /* 8K */
+       #ifndef MAX_RECVBUF_SZ
+                       #ifndef CONFIG_MINIMAL_MEMORY_USAGE
+                                /* #define MAX_RECVBUF_SZ (32768) */ /* 32k */
+                                /* #define MAX_RECVBUF_SZ (16384) */ /* 16K */
+                                /* #define MAX_RECVBUF_SZ (10240) */ /* 10K */
+                                #ifdef CONFIG_PLATFORM_MSTAR
+                                        #define MAX_RECVBUF_SZ (8192) /* 8K */
 				#else
 					#define MAX_RECVBUF_SZ (15360) /* 15k < 16k */
 				#endif
 				/* #define MAX_RECVBUF_SZ (8192+1024) */ /* 8K+1k */
-			#else
-				#define MAX_RECVBUF_SZ (4000) /* about 4K */
-			#endif
-		#endif
-	#endif /* !MAX_RECVBUF_SZ */
+                       #else
+                               #define MAX_RECVBUF_SZ (4000) /* about 4K */
+                       #endif
+       #endif /* !MAX_RECVBUF_SZ */
 
 #elif defined(CONFIG_PCI_HCI)
 	/* #ifndef CONFIG_MINIMAL_MEMORY_USAGE */


### PR DESCRIPTION
## Summary
- drop obsolete PLATFORM_OS_CE check in `rtl8703b_recv.h`

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_68474bbdf2b4833189a8a8bc2c629066