### PR TITLE
Remove legacy CE support

### DIFF
--- a/include/rtl8723b_recv.h
+++ b/include/rtl8723b_recv.h
@@ -22,9 +22,6 @@
 #if defined(CONFIG_USB_HCI)
 
 	#ifndef MAX_RECVBUF_SZ
-		#ifdef PLATFORM_OS_CE
-			#define MAX_RECVBUF_SZ (8192+1024) /* 8K+1k */
-		#else
 			#ifndef CONFIG_MINIMAL_MEMORY_USAGE
 				/* #define MAX_RECVBUF_SZ (32768) */ /* 32k */
 				/* #define MAX_RECVBUF_SZ (16384) */ /* 16K */


### PR DESCRIPTION
## Summary
- drop obsolete `PLATFORM_OS_CE` branch in `rtl8723b_recv.h`

## Testing
- `sudo apt-get install -y build-essential flex bison bc wget tar xz-utils crossbuild-essential-arm64 libssl-dev libelf-dev`
- `./tests/test_kernel_5.4.sh` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68474bc65b208331ab956361cf011c5c