### PR TITLE
Remove obsolete PLATFORM_OS_CE code

### DIFF
--- a/include/rtl8812a_recv.h
+++ b/include/rtl8812a_recv.h
@@ -17,30 +17,26 @@
 
 #if defined(CONFIG_USB_HCI)
 
-	#ifndef MAX_RECVBUF_SZ
-		#ifdef PLATFORM_OS_CE
-			#define MAX_RECVBUF_SZ (8192+1024) /* 8K+1k */
-		#else
-			#ifndef CONFIG_MINIMAL_MEMORY_USAGE
-				#ifdef CONFIG_PREALLOC_RX_SKB_BUFFER
-					#define MAX_RECVBUF_SZ (rtw_rtkm_get_buff_size()) /*depend rtkm*/
-				#else
-					#define MAX_RECVBUF_SZ (32768)  /*32k*/
-				#endif
-				/* #define MAX_RECVBUF_SZ (24576) */ /* 24k */
-				/* #define MAX_RECVBUF_SZ (20480) */ /* 20K */
-				/* #define MAX_RECVBUF_SZ (10240) */ /* 10K */
-				/* #define MAX_RECVBUF_SZ (15360) */ /* 15k < 16k */
-				/* #define MAX_RECVBUF_SZ (8192+1024) */ /* 8K+1k */
-				#ifdef CONFIG_PLATFORM_NOVATEK_NT72668
-					#undef MAX_RECVBUF_SZ
-					#define MAX_RECVBUF_SZ (15360) /* 15k < 16k */
-				#endif /* CONFIG_PLATFORM_NOVATEK_NT72668 */
-			#else
-				#define MAX_RECVBUF_SZ (4000) /* about 4K */
-			#endif
-		#endif
-	#endif /* !MAX_RECVBUF_SZ */
+       #ifndef MAX_RECVBUF_SZ
+               #ifndef CONFIG_MINIMAL_MEMORY_USAGE
+                       #ifdef CONFIG_PREALLOC_RX_SKB_BUFFER
+                               #define MAX_RECVBUF_SZ (rtw_rtkm_get_buff_size()) /*depend rtkm*/
+                       #else
+                               #define MAX_RECVBUF_SZ (32768)  /*32k*/
+                       #endif
+                       /* #define MAX_RECVBUF_SZ (24576) */ /* 24k */
+                       /* #define MAX_RECVBUF_SZ (20480) */ /* 20K */
+                       /* #define MAX_RECVBUF_SZ (10240) */ /* 10K */
+                       /* #define MAX_RECVBUF_SZ (15360) */ /* 15k < 16k */
+                       /* #define MAX_RECVBUF_SZ (8192+1024) */ /* 8K+1k */
+                       #ifdef CONFIG_PLATFORM_NOVATEK_NT72668
+                               #undef MAX_RECVBUF_SZ
+                               #define MAX_RECVBUF_SZ (15360) /* 15k < 16k */
+                       #endif /* CONFIG_PLATFORM_NOVATEK_NT72668 */
+               #else
+                       #define MAX_RECVBUF_SZ (4000) /* about 4K */
+               #endif
+       #endif /* !MAX_RECVBUF_SZ */
 
 #elif defined(CONFIG_PCI_HCI)
 	/* #ifndef CONFIG_MINIMAL_MEMORY_USAGE */


### PR DESCRIPTION
## Summary
- clean up `include/rtl8812a_recv.h` by deleting the `PLATFORM_OS_CE` path

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68474bce6a908331b851631dc085d12a