### PR TITLE
Remove CE platform code

### DIFF
--- a/include/rtl8814a_recv.h
+++ b/include/rtl8814a_recv.h
@@ -17,11 +17,8 @@
 
 #if defined(CONFIG_USB_HCI)
 
-	#ifndef MAX_RECVBUF_SZ
-		#ifdef PLATFORM_OS_CE
-			#define MAX_RECVBUF_SZ (8192+1024) /* 8K+1k */
-		#else
-			#ifndef CONFIG_MINIMAL_MEMORY_USAGE
+#ifndef MAX_RECVBUF_SZ
+#ifndef CONFIG_MINIMAL_MEMORY_USAGE
 				#ifdef CONFIG_PLATFORM_MSTAR
 					#define MAX_RECVBUF_SZ (8192) /* 8K */
 				#else
@@ -35,9 +32,7 @@
 			#else
 				#define MAX_RECVBUF_SZ (4000) /* about 4K */
 			#endif
-		#endif
 	#endif /* !MAX_RECVBUF_SZ */
-
 #elif defined(CONFIG_PCI_HCI)
 	/* #ifndef CONFIG_MINIMAL_MEMORY_USAGE */
 	/*	#define MAX_RECVBUF_SZ (9100) */


### PR DESCRIPTION
## Summary
- remove `PLATFORM_OS_CE` condition from the 8814A RX header

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_68474bd30b408331b5df0c2cb792032a