### PR TITLE
Remove platform checks from debug header

### DIFF
--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -28,37 +28,18 @@ enum {
 
 #define DRIVER_PREFIX "RTW: "
 
-#ifdef PLATFORM_OS_CE
-extern void rtl871x_cedbg(const char *fmt, ...);
-#endif
-
-#ifdef PLATFORM_WINDOWS
-	#define RTW_PRINT do {} while (0)
-	#define RTW_ERR do {} while (0)
-	#define RTW_WARN do {} while (0)
-	#define RTW_INFO do {} while (0)
-	#define RTW_DBG do {} while (0)
-	#define RTW_PRINT_SEL do {} while (0)
-	#define _RTW_PRINT do {} while (0)
-	#define _RTW_ERR do {} while (0)
-	#define _RTW_WARN do {} while (0)
-	#define _RTW_INFO do {} while (0)
-	#define _RTW_DBG do {} while (0)
-	#define _RTW_PRINT_SEL do {} while (0)
-#else
-	#define RTW_PRINT(x, ...) do {} while (0)
-	#define RTW_ERR(x, ...) do {} while (0)
-	#define RTW_WARN(x,...) do {} while (0)
-	#define RTW_INFO(x,...) do {} while (0)
-	#define RTW_DBG(x,...) do {} while (0)
-	#define RTW_PRINT_SEL(x,...) do {} while (0)
-	#define _RTW_PRINT(x, ...) do {} while (0)
-	#define _RTW_ERR(x, ...) do {} while (0)
-	#define _RTW_WARN(x,...) do {} while (0)
-	#define _RTW_INFO(x,...) do {} while (0)
-	#define _RTW_DBG(x,...) do {} while (0)
-	#define _RTW_PRINT_SEL(x,...) do {} while (0)
-#endif
+#define RTW_PRINT(x, ...) do {} while (0)
+#define RTW_ERR(x, ...) do {} while (0)
+#define RTW_WARN(x, ...) do {} while (0)
+#define RTW_INFO(x, ...) do {} while (0)
+#define RTW_DBG(x, ...) do {} while (0)
+#define RTW_PRINT_SEL(x, ...) do {} while (0)
+#define _RTW_PRINT(x, ...) do {} while (0)
+#define _RTW_ERR(x, ...) do {} while (0)
+#define _RTW_WARN(x, ...) do {} while (0)
+#define _RTW_INFO(x, ...) do {} while (0)
+#define _RTW_DBG(x, ...) do {} while (0)
+#define _RTW_PRINT_SEL(x, ...) do {} while (0)
 
 #define RTW_INFO_DUMP(_TitleString, _HexData, _HexDataLen) do {} while (0)
 #define RTW_DBG_DUMP(_TitleString, _HexData, _HexDataLen) do {} while (0)
@@ -73,19 +54,9 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 #undef _dbgdump
 #undef _seqdump
 
-#if defined(PLATFORM_WINDOWS) && defined(PLATFORM_OS_XP)
-	#define _dbgdump DbgPrint
-	#define KERN_CONT
-	#define _seqdump(sel, fmt, arg...) _dbgdump(fmt, ##arg)
-#elif defined(PLATFORM_WINDOWS) && defined(PLATFORM_OS_CE)
-	#define _dbgdump rtl871x_cedbg
-	#define KERN_CONT
-	#define _seqdump(sel, fmt, arg...) _dbgdump(fmt, ##arg)
-#elif defined PLATFORM_LINUX
-       #define _dbgdump printk
-       /* KERN_CONT is available in kernels >= 2.6.24 */
-       #define _seqdump seq_printf
-#endif
+#define _dbgdump printk
+/* KERN_CONT is available in kernels >= 2.6.24 */
+#define _seqdump seq_printf
 
 void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 								bool _idx_show, const u8 *_hexdata, int _hexdatalen);


### PR DESCRIPTION
## Summary
- drop PLATFORM_WINDOWS, PLATFORM_OS_XP and PLATFORM_OS_CE checks
- set default printk and seqdump implementations
- install packages for building and run kernel 5.4 test

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848a1c52ef483319c94ee502242c5f1