### PR TITLE
Remove unused platform code

### DIFF
--- a/include/rtw_io.h
+++ b/include/rtw_io.h
@@ -18,12 +18,7 @@
 
 #define NUM_IOREQ		8
 
-#ifdef PLATFORM_WINDOWS
-	#define MAX_PROT_SZ	64
-#endif
-#ifdef PLATFORM_LINUX
-	#define MAX_PROT_SZ	(64-16)
-#endif
+#define MAX_PROT_SZ	(64-16)
 
 #define _IOREADY			0
 #define _IO_WAIT_COMPLETE   1
@@ -141,25 +136,10 @@ struct io_req {
 	u8	*pbuf;
 	_sema	sema;
 
-#ifdef PLATFORM_OS_CE
-#ifdef CONFIG_USB_HCI
-	/* URB handler for rtw_write_mem */
-	USB_TRANSFER usb_transfer_write_mem;
-#endif
-#endif
 
 	void (*_async_io_callback)(_adapter *padater, struct io_req *pio_req, u8 *cnxt);
 	u8 *cnxt;
 
-#ifdef PLATFORM_OS_XP
-	PMDL pmdl;
-	PIRP  pirp;
-
-#ifdef CONFIG_SDIO_HCI
-	PSDBUS_REQUEST_PACKET sdrp;
-#endif
-
-#endif
 
 
 };


### PR DESCRIPTION
## Summary
- remove leftover PLATFORM_* blocks from `include/rtw_io.h`
- pass kernel 5.4 build test

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848a1cb1d148331bd9c2867091f1c1e