### PR TITLE
Remove obsolete OS code

### DIFF
--- a/include/rtw_xmit.h
+++ b/include/rtw_xmit.h
@@ -61,18 +61,14 @@
 	#define NR_XMITBUFF	(128)
 #endif
 
-#ifdef PLATFORM_OS_CE
-	#define XMITBUF_ALIGN_SZ 4
+#ifdef CONFIG_PCI_HCI
+       #define XMITBUF_ALIGN_SZ 4
 #else
-	#ifdef CONFIG_PCI_HCI
-		#define XMITBUF_ALIGN_SZ 4
-	#else
-		#ifdef USB_XMITBUF_ALIGN_SZ
-			#define XMITBUF_ALIGN_SZ (USB_XMITBUF_ALIGN_SZ)
-		#else
-			#define XMITBUF_ALIGN_SZ 512
-		#endif
-	#endif
+       #ifdef USB_XMITBUF_ALIGN_SZ
+               #define XMITBUF_ALIGN_SZ (USB_XMITBUF_ALIGN_SZ)
+       #else
+               #define XMITBUF_ALIGN_SZ 512
+       #endif
 #endif
 
 /* xmit extension buff defination */
@@ -597,23 +593,12 @@ struct xmit_buf {
 	u8 bulkout_id; /* for halmac */
 #endif /* RTW_HALMAC */
 
-#if defined(PLATFORM_OS_XP) || defined(PLATFORM_LINUX) 
-	PURB	pxmit_urb[8];
-	dma_addr_t dma_transfer_addr;	/* (in) dma addr for transfer_buffer */
-#endif
-
-#ifdef PLATFORM_OS_XP
-	PIRP		pxmit_irp[8];
-#endif
-
-#ifdef PLATFORM_OS_CE
-	USB_TRANSFER	usb_transfer_write_port;
-#endif
+	PURB    pxmit_urb[8];
+	dma_addr_t dma_transfer_addr;   /* (in) dma addr for transfer_buffer */
 
 	u8 bpending[8];
 
 	sint last[8];
-
 #endif
 
 #if defined(CONFIG_SDIO_HCI) || defined(CONFIG_GSPI_HCI)
@@ -624,11 +609,6 @@ struct xmit_buf {
 	u32 ff_hwaddr;
 	u8	pg_num;
 	u8	agg_num;
-#ifdef PLATFORM_OS_XP
-	PMDL pxmitbuf_mdl;
-	PIRP  pxmitbuf_irp;
-	PSDBUS_REQUEST_PACKET pxmitbuf_sdrp;
-#endif
 #endif
 
 #ifdef CONFIG_PCI_HCI
@@ -795,10 +775,6 @@ struct	xmit_priv	{
 	_sema	tx_retevt;/* all tx return event; */
 	u8		txirp_cnt;
 
-#ifdef PLATFORM_OS_CE
-	USB_TRANSFER	usb_transfer_write_port;
-	/*	USB_TRANSFER	usb_transfer_write_mem; */
-#endif
 #ifdef PLATFORM_LINUX
 	struct tasklet_struct xmit_tasklet;
 #endif


### PR DESCRIPTION
## Summary
- strip PLATFORM_OS_XP and PLATFORM_OS_CE cases from rtw_xmit.h
- set up build deps and run kernel 5.4 test

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848a1d5e8648331b3bd33759428b761