### PR TITLE
Remove unused field from security_priv

### DIFF
--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -192,9 +192,6 @@ struct security_priv {
 	u32 ndisencryptstatus;	/* NDIS_802_11_ENCRYPTION_STATUS */
 
 	NDIS_802_11_WEP ndiswep;
-#ifdef PLATFORM_WINDOWS
-	u8 KeyMaterial[16];/* variable length depending on above field. */
-#endif
 
 	u8 assoc_info[600];
 	u8 szofcapability[256]; /* for wpa2 usage */


### PR DESCRIPTION
## Summary
- drop stale KeyMaterial member from `security_priv`
- build the module against Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_6848a1d77a10833198a9428180a2e03b