### PR TITLE
include: remove PLATFORM_WINDOWS query prototypes

### DIFF
--- a/include/rtw_ioctl_query.h
+++ b/include/rtw_ioctl_query.h
@@ -15,11 +15,4 @@
 #ifndef _RTW_IOCTL_QUERY_H_
 #define _RTW_IOCTL_QUERY_H_
 
-
-#ifdef PLATFORM_WINDOWS
-u8 query_802_11_capability(_adapter	*padapter, u8 *pucBuf, u32 *pulOutLen);
-u8 query_802_11_association_information(_adapter *padapter, PNDIS_802_11_ASSOCIATION_INFORMATION pAssocInfo);
-#endif
-
-
 #endif


### PR DESCRIPTION
## Summary
- drop Windows-only code from `rtw_ioctl_query.h`
- run driver build for Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848a1dd49348331b484549b7cd4554a