### PR TITLE
Remove unused SDIO Windows branches

### DIFF
--- a/include/sdio_ops.h
+++ b/include/sdio_ops.h
@@ -25,23 +25,6 @@
 #include <sdio_ops_linux.h>
 #endif
 
-#ifdef PLATFORM_WINDOWS
-
-#ifdef PLATFORM_OS_XP
-#include <sdio_ops_xp.h>
-struct async_context {
-	PMDL pmdl;
-	PSDBUS_REQUEST_PACKET sdrp;
-	unsigned char *r_buf;
-	unsigned char *padapter;
-};
-#endif
-
-#ifdef PLATFORM_OS_CE
-#include <sdio_ops_ce.h>
-#endif
-
-#endif /* PLATFORM_WINDOWS */
 
 
 extern void sdio_set_intf_ops(_adapter *padapter, struct _io_ops *pops);


### PR DESCRIPTION
## Summary
- remove legacy Windows code paths from `sdio_ops.h`
- run Linux 5.4 build test

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a1ac3288331ab64e4cbd8d6aba5