### PR TITLE
Remove unused CE code

### DIFF
--- a/include/sdio_ops_ce.h
+++ b/include/sdio_ops_ce.h
@@ -21,29 +21,5 @@
 #include <osdep_intf.h>
 
 
-#ifdef PLATFORM_OS_CE
-
-
-extern u8 sdbus_cmd52r_ce(struct intf_priv *pintfpriv, u32 addr);
-
-
-extern void sdbus_cmd52w_ce(struct intf_priv *pintfpriv, u32 addr, u8 val8);
-
-
-uint sdbus_read_blocks_to_membuf_ce(struct intf_priv *pintfpriv, u32 addr, u32 cnt, u8 *pbuf);
-
-extern uint sdbus_read_bytes_to_membuf_ce(struct intf_priv *pintfpriv, u32 addr, u32 cnt, u8 *pbuf);
-
-
-extern uint sdbus_write_blocks_from_membuf_ce(struct intf_priv *pintfpriv, u32 addr, u32 cnt, u8 *pbuf, u8 async);
-
-extern uint sdbus_write_bytes_from_membuf_ce(struct intf_priv *pintfpriv, u32 addr, u32 cnt, u8 *pbuf);
-extern u8 sdbus_func1cmd52r_ce(struct intf_priv *pintfpriv, u32 addr);
-extern void sdbus_func1cmd52w_ce(struct intf_priv *pintfpriv, u32 addr, u8 val8);
-extern uint sdbus_read_reg(struct intf_priv *pintfpriv, u32 addr, u32 cnt, void *pdata);
-extern uint sdbus_write_reg(struct intf_priv *pintfpriv, u32 addr, u32 cnt, void *pdata);
-extern void sdio_read_int(_adapter *padapter, u32 addr, u8 sz, void *pdata);
-
-#endif
 
 #endif


### PR DESCRIPTION
## Summary
- remove the obsolete `PLATFORM_OS_CE` block from `sdio_ops_ce.h`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a1b84d88331a8c1af3f79c81150