### PR TITLE
Remove Windows CE code and validate build

### DIFF
--- a/include/sdio_osintf.h
+++ b/include/sdio_osintf.h
@@ -15,11 +15,4 @@
 #ifndef __SDIO_OSINTF_H__
 #define __SDIO_OSINTF_H__
 
-
-#ifdef PLATFORM_OS_CE
-extern NDIS_STATUS ce_sd_get_dev_hdl(PADAPTER padapter);
-SD_API_STATUS ce_sd_int_callback(SD_DEVICE_HANDLE hDevice, PADAPTER padapter);
-extern void sd_setup_irs(PADAPTER padapter);
-#endif
-
 #endif


### PR DESCRIPTION
## Summary
- remove unused `PLATFORM_OS_CE` code in `sdio_osintf.h`
- build the driver against kernel 5.4 to verify it still compiles

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a1dea7483318bf522527d2d7406