### PR TITLE
Remove obsolete platform macros

### DIFF
--- a/include/xmit_osdep.h
+++ b/include/xmit_osdep.h
@@ -25,31 +25,6 @@ struct pkt_file {
 	SIZE_T buf_len;
 };
 
-#ifdef PLATFORM_WINDOWS
-
-#ifdef PLATFORM_OS_XP
-#ifdef CONFIG_USB_HCI
-#include <usb.h>
-#include <usbdlib.h>
-#include <usbioctl.h>
-#endif
-#endif
-
-#ifdef CONFIG_GSPI_HCI
-	#define NR_XMITFRAME     64
-#else
-	#define NR_XMITFRAME     128
-#endif
-
-#define ETH_ALEN	6
-
-extern NDIS_STATUS rtw_xmit_entry(
-	IN _nic_hdl		cnxt,
-	IN NDIS_PACKET		*pkt,
-	IN UINT				flags
-);
-
-#endif /* PLATFORM_WINDOWS */
 #ifdef PLATFORM_LINUX
 
 #define NR_XMITFRAME	256


### PR DESCRIPTION
## Summary
- delete `PLATFORM_WINDOWS` and `PLATFORM_OS_XP` handling from `xmit_osdep.h`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a2290f88331a3034d90fa5525c2