### PR TITLE
Remove outdated Windows checks

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -17,11 +17,6 @@
 #include <drv_types.h>
 #include <hal_data.h>
 
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-
-	#error "Shall be Linux or Windows, but not both!\n"
-
-#endif
 
 
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
## Summary
- remove the redundant PLATFORM_WINDOWS sanity check in `os_intfs.c`

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_684e9a2d89e0833182e745dcde4ef4be