### PR TITLE
core: remove obsolete platform check

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -23,9 +23,6 @@
 #error "CONFIG_USB_HCI shall be on!\n"
 #endif
 
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-#error "Shall be Linux or Windows, but not both!\n"
-#endif
 
 #ifdef CONFIG_80211N_HT
 extern int rtw_ht_enable;


### PR DESCRIPTION
## Summary
- remove the dead `PLATFORM_LINUX`/`PLATFORM_WINDOWS` check in `usb_intf.c`

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_684e9a2eadc083319658fb163cf296d6