### PR TITLE
Remove OS_XP code from rtw_cmd.c

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -164,15 +164,6 @@ sint _rtw_init_evt_priv(struct evt_priv *pevtpriv)
 
 	pevtpriv->c2h_mem = pevtpriv->allocated_c2h_mem +  4\
 			    - ((u32)(pevtpriv->allocated_c2h_mem) & 3);
-#ifdef PLATFORM_OS_XP
-	pevtpriv->pc2h_mdl = IoAllocateMdl((u8 *)pevtpriv->c2h_mem, C2H_MEM_SZ , FALSE, FALSE, NULL);
-
-	if (pevtpriv->pc2h_mdl == NULL) {
-		res = _FAIL;
-		goto exit;
-	}
-	MmBuildMdlForNonPagedPool(pevtpriv->pc2h_mdl);
-#endif
 #endif /* end of CONFIG_SDIO_HCI */
 
 	_rtw_init_queue(&(pevtpriv->evt_queue));


### PR DESCRIPTION
## Summary
- delete dead `PLATFORM_OS_XP` block in `rtw_cmd.c`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a40111483319f984edbe603f58f