### PR TITLE
Remove unused PLATFORM_WINDOWS code

### DIFF
--- a/core/rtw_io.c
+++ b/core/rtw_io.c
@@ -47,9 +47,6 @@ jackson@realtek.com.tw
 #include <drv_types.h>
 #include <hal_data.h>
 
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-	#error "Shall be Linux or Windows, but not both!\n"
-#endif
 
 #if defined(CONFIG_SDIO_HCI) || defined(CONFIG_PLATFORM_RTL8197D)
 	#define rtw_le16_to_cpu(val)		val


### PR DESCRIPTION
## Summary
- clean up obsolete PLATFORM_WINDOWS check in `core/rtw_io.c`
- install build dependencies and build against kernel 5.4

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_684e9a410420833190d5f9fcea6b1788