### PR TITLE
Remove Windows power check

### DIFF
--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -2100,9 +2100,6 @@ void rtw_init_pwrctrl_priv(PADAPTER padapter)
 #endif
 
 
-#ifdef PLATFORM_WINDOWS
-	pwrctrlpriv->pnp_current_pwr_state = NdisDeviceStateD0;
-#endif
 
 	_init_pwrlock(&pwrctrlpriv->lock);
 	_init_pwrlock(&pwrctrlpriv->check_32k_lock);


### PR DESCRIPTION
## Summary
- remove `PLATFORM_WINDOWS` condition from power control

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_684e9a4569d88331a6471f700f8363f1