### PR TITLE
Remove redundant platform check

### DIFF
--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -16,13 +16,6 @@
 
 #include <drv_types.h>
 
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-
-	#error "Shall be Linux or Windows, but not both!\n"
-
-#endif
-
-
 bool test_st_match_rule(_adapter *adapter, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
 {
 	if (ntohs(*((u16 *)local_port)) == 5001 || ntohs(*((u16 *)remote_port)) == 5001)


### PR DESCRIPTION
## Summary
- remove unnecessary `PLATFORM_LINUX` and `PLATFORM_WINDOWS` guard in `rtw_sta_mgt.c`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e9a4aa8ec83319545f6671a90bf7e