### PR TITLE
core: remove PLATFORM_WINDOWS guard

### DIFF
--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -17,11 +17,6 @@
 #include <drv_types.h>
 #include <hal_data.h>
 
-#if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
-	#error "Shall be Linux or Windows, but not both!\n"
-#endif
-
-
 static u8 P802_1H_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0xf8 };
 static u8 RFC1042_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0x00 };
 


### PR DESCRIPTION
## Summary
- drop obsolete PLATFORM_WINDOWS check in rtw_xmit.c
- verify build against Linux 5.4

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_684e9a4b434c8331bdec8586f8e2e426