### PR TITLE
Remove obsolete buffer alignment check

### DIFF
--- a/include/rtw_cmd.h
+++ b/include/rtw_cmd.h
@@ -26,11 +26,7 @@
 #define MAX_RSPSZ	512
 #define MAX_EVTSZ	1024
 
-#ifdef PLATFORM_OS_CE
-	#define CMDBUFF_ALIGN_SZ 4
-#else
-	#define CMDBUFF_ALIGN_SZ 512
-#endif
+#define CMDBUFF_ALIGN_SZ 512
 
 struct cmd_obj {
 	_adapter *padapter;


### PR DESCRIPTION
## Summary
- clean up obsolete PLATFORM_OS_CE block in `include/rtw_cmd.h`
- install required packages and build against kernel 5.4

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ecfc0703c83318d6a3c6641597c2c