### PR TITLE
Remove XP-specific include

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -16,14 +16,6 @@
 #define __IEEE80211_H
 
 
-#ifndef CONFIG_RTL8711FW
-
-	#if defined PLATFORM_OS_XP
-		#include <ntstrsafe.h>
-	#endif
-#else
-
-#endif
 
 #define MGMT_QUEUE_NUM 5
 


### PR DESCRIPTION
## Summary
- drop unused Windows XP include

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ecfb6ae888331b3cd7f5c24ac03af