### PR TITLE
core: replace deprecated simple_strtoul

### DIFF
--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -8597,17 +8597,33 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 			goto exit;
 		}
 
-		/* rmap addr cnts */
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+               /* rmap addr cnts */
+               {
+                       unsigned long val;
+                       int ret;
 
-		cnts = simple_strtoul(tmp[2], &ptmp, 10);
-		if (cnts == 0) {
-			RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
-			err = -EINVAL;
-			goto exit;
-		}
-		RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val;
+               }
+               RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+
+               {
+                       int val;
+                       int ret;
+
+                       ret = kstrtoint(tmp[2], 10, &val);
+                       if (ret || val == 0) {
+                               RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       cnts = (u16)val;
+               }
+               RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
 
 		EFUSE_GetEfuseDefinition(padapter, EFUSE_WIFI, TYPE_EFUSE_MAP_LEN , (PVOID)&max_available_len, _FALSE);
 		if ((addr + cnts) > max_available_len) {
@@ -8912,17 +8928,33 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 
 		BTEfuse_PowerSwitch(padapter, 1, _TRUE);
 
-		/* rmap addr cnts */
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		RTW_INFO("%s: addr=0x%X\n", __FUNCTION__, addr);
+               /* rmap addr cnts */
+               {
+                       unsigned long val;
+                       int ret;
 
-		cnts = simple_strtoul(tmp[2], &ptmp, 10);
-		if (cnts == 0) {
-			RTW_INFO("%s: btrmap Fail!! cnts error!\n", __FUNCTION__);
-			err = -EINVAL;
-			goto exit;
-		}
-		RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val;
+               }
+               RTW_INFO("%s: addr=0x%X\n", __FUNCTION__, addr);
+
+               {
+                       int val;
+                       int ret;
+
+                       ret = kstrtoint(tmp[2], 10, &val);
+                       if (ret || val == 0) {
+                               RTW_INFO("%s: btrmap Fail!! cnts error!\n", __FUNCTION__);
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       cnts = (u16)val;
+               }
+               RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
 #ifndef RTW_HALMAC
 		EFUSE_GetEfuseDefinition(padapter, EFUSE_BT, TYPE_EFUSE_MAP_LEN, (PVOID)&max_available_len, _FALSE);
 		if ((addr + cnts) > max_available_len) {
@@ -9026,17 +9058,33 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 			err = -EINVAL;
 			goto exit;
 		}
-		/* rmap addr cnts */
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+               /* rmap addr cnts */
+               {
+                       unsigned long val;
+                       int ret;
 
-		cnts = simple_strtoul(tmp[2], &ptmp, 10);
-		if (cnts == 0) {
-			RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
-			err = -EINVAL;
-			goto exit;
-		}
-		RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val;
+               }
+               RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+
+               {
+                       int val;
+                       int ret;
+
+                       ret = kstrtoint(tmp[2], 10, &val);
+                       if (ret || val == 0) {
+                               RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       cnts = (u16)val;
+               }
+               RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
 
 		/*		RTW_INFO("%s: data={", __FUNCTION__); */
 		*extra = 0;
@@ -9051,17 +9099,33 @@ static int rtw_mp_efuse_get(struct net_device *dev,
 			err = -EINVAL;
 			goto exit;
 		}
-		/* rmap addr cnts */
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+               /* rmap addr cnts */
+               {
+                       unsigned long val;
+                       int ret;
 
-		cnts = simple_strtoul(tmp[2], &ptmp, 10);
-		if (cnts == 0) {
-			RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
-			err = -EINVAL;
-			goto exit;
-		}
-		RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val;
+               }
+               RTW_INFO("%s: addr=%x\n", __FUNCTION__, addr);
+
+               {
+                       int val;
+                       int ret;
+
+                       ret = kstrtoint(tmp[2], 10, &val);
+                       if (ret || val == 0) {
+                               RTW_INFO("%s: rmap Fail!! cnts error!\n", __FUNCTION__);
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       cnts = (u16)val;
+               }
+               RTW_INFO("%s: cnts=%d\n", __FUNCTION__, cnts);
 
 		/*		RTW_INFO("%s: data={", __FUNCTION__); */
 		*extra = 0;
@@ -9217,10 +9281,19 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		rtw_read8(padapter, EFUSE_CTRL);
 #endif /* RTW_HALMAC */
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
 
-		cnts = strlen(tmp[2]);
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
+
+               cnts = strlen(tmp[2]);
 		if (cnts % 2) {
 			err = -EINVAL;
 			goto exit;
@@ -9272,8 +9345,17 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 			goto exit;
 		}
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
+
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
 
 		cnts = strlen(tmp[2]);
 		if (cnts % 2) {
@@ -9304,8 +9386,17 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 			goto exit;
 		}
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
+
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
 
 		cnts = strlen(tmp[2]);
 		if (cnts % 2) {
@@ -9507,8 +9598,17 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		BTEfuse_PowerSwitch(padapter, 1, _FALSE);
 #endif /* RTW_HALMAC */
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
+
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
 
 		cnts = strlen(tmp[2]);
 		if (cnts % 2) {
@@ -9561,8 +9661,17 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 			goto exit;
 		}
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
+
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
 
 		cnts = strlen(tmp[2]);
 		if (cnts % 2) {
@@ -9726,8 +9835,17 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 			goto exit;
 		}
 
-		addr = simple_strtoul(tmp[1], &ptmp, 16);
-		addr &= 0xFFF;
+               {
+                       unsigned long val;
+                       int ret;
+
+                       ret = kstrtoul(tmp[1], 16, &val);
+                       if (ret) {
+                               err = -EINVAL;
+                               goto exit;
+                       }
+                       addr = (u16)val & 0xFFF;
+               }
 
 		cnts = strlen(tmp[2]);
 		if (cnts % 2) {

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -226,9 +226,19 @@ static int rtw_android_pno_setup(struct net_device *net, char *command, int tota
 					 __func__, tlv_size_left);
 				goto exit_proc;
 			}
-			str_ptr++;
-			pno_time = simple_strtoul(str_ptr, &str_ptr, 16);
-			RTW_INFO("%s: pno_time=%d\n", __func__, pno_time);
+                       {
+                               unsigned long val;
+                               int ret;
+
+                               str_ptr++;
+                               ret = kstrtoul(str_ptr, 16, &val);
+                               if (ret)
+                                       goto exit_proc;
+                               pno_time = (int)val;
+                               str_ptr += strspn(str_ptr,
+                                                "0123456789abcdefABCDEF");
+                       }
+                       RTW_INFO("%s: pno_time=%d\n", __func__, pno_time);
 
 			if (str_ptr[0] != 0) {
 				if ((str_ptr[0] != PNO_TLV_FREQ_REPEAT)) {
@@ -236,18 +246,38 @@ static int rtw_android_pno_setup(struct net_device *net, char *command, int tota
 						 __func__);
 					goto exit_proc;
 				}
-				str_ptr++;
-				pno_repeat = simple_strtoul(str_ptr, &str_ptr, 16);
-				RTW_INFO("%s :got pno_repeat=%d\n", __FUNCTION__, pno_repeat);
+                               {
+                                       unsigned long val;
+                                       int ret;
+
+                                       str_ptr++;
+                                       ret = kstrtoul(str_ptr, 16, &val);
+                                       if (ret)
+                                               goto exit_proc;
+                                       pno_repeat = (int)val;
+                                       str_ptr += strspn(str_ptr,
+                                                        "0123456789abcdefABCDEF");
+                               }
+                               RTW_INFO("%s :got pno_repeat=%d\n", __FUNCTION__, pno_repeat);
 				if (str_ptr[0] != PNO_TLV_FREQ_EXPO_MAX) {
 					RTW_INFO("%s FREQ_EXPO_MAX corrupted field size\n",
 						 __func__);
 					goto exit_proc;
 				}
-				str_ptr++;
-				pno_freq_expo_max = simple_strtoul(str_ptr, &str_ptr, 16);
-				RTW_INFO("%s: pno_freq_expo_max=%d\n",
-					 __func__, pno_freq_expo_max);
+                               {
+                                       unsigned long val;
+                                       int ret;
+
+                                       str_ptr++;
+                                       ret = kstrtoul(str_ptr, 16, &val);
+                                       if (ret)
+                                               goto exit_proc;
+                                       pno_freq_expo_max = (int)val;
+                                       str_ptr += strspn(str_ptr,
+                                                        "0123456789abcdefABCDEF");
+                               }
+                               RTW_INFO("%s: pno_freq_expo_max=%d\n",
+                                        __func__, pno_freq_expo_max);
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary
- replace simple_strtoul in Android and ioctl handlers
- use kstrtoul/kstrtoint with return checks
- fix compile issue in efuse map handler

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_6858110a4e5c83318700ba6573669433