### PR TITLE
Replace set_fs usage with kernel APIs

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/fs.h>
 
 #if defined(CONFIG_WOWLAN) || defined(CONFIG_AP_WOWLAN)
 	#include <linux/inetdevice.h>
@@ -4744,9 +4745,8 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 {
 
 	int i = 0;
-	struct file *fp;
-	mm_segment_t fs;
-	loff_t pos = 0;
+       struct file *fp;
+       loff_t pos = 0;
 	u8 *source = NULL;
 	long len = 0;
 
@@ -4782,18 +4782,13 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		return 0;
 	}
 
-	fs = get_fs();
-	set_fs(KERNEL_DS);
+       source = rtw_zmalloc(2048);
 
-	source = rtw_zmalloc(2048);
-
-	if (source != NULL) {
-		len = vfs_read(fp, source, len, &pos);
-		rtw_parse_cipher_list(nlo_info, source);
-		rtw_mfree(source, 2048);
-	}
-
-	set_fs(fs);
+       if (source != NULL) {
+               len = kernel_read(fp, source, len, &pos);
+               rtw_parse_cipher_list(nlo_info, source);
+               rtw_mfree(source, 2048);
+       }
 	filp_close(fp, NULL);
 
 	RTW_INFO("-%s-\n", __func__);


### PR DESCRIPTION
## Summary
- use `kernel_sendmsg` in btcoex socket handling
- use `kernel_read` for reading wpa_supplicant config
- use `kernel_sendmsg`/`kernel_recvmsg` in route dump logic
- add required header includes

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68581123e7ac83319fba4c7b47c12a13