### PR TITLE
core: use kvmalloc helpers

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -48,7 +48,7 @@
 #include <linux/kthread.h>
 #include <linux/list.h>
 #include <linux/vmalloc.h>
-
+#include <linux/mm.h>
 
 #include <uapi/linux/limits.h>
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -75,9 +75,9 @@ u32 rtw_atoi(u8 *s)
 
 inline void *_rtw_vmalloc(u32 sz)
 {
-	void *pbuf;
+       void *pbuf;
 #ifdef PLATFORM_LINUX
-	pbuf = vmalloc(sz);
+       pbuf = kvmalloc(sz, GFP_KERNEL);
 #endif
 
 
@@ -95,20 +95,18 @@ inline void *_rtw_vmalloc(u32 sz)
 
 inline void *_rtw_zvmalloc(u32 sz)
 {
-	void *pbuf;
+       void *pbuf;
 #ifdef PLATFORM_LINUX
-	pbuf = _rtw_vmalloc(sz);
-	if (pbuf != NULL)
-		memset(pbuf, 0, sz);
+       pbuf = kvzalloc(sz, GFP_KERNEL);
 #endif
 
-	return pbuf;
+       return pbuf;
 }
 
 inline void _rtw_vmfree(void *pbuf, u32 sz)
 {
 #ifdef PLATFORM_LINUX
-	vfree(pbuf);
+       kvfree(pbuf);
 #endif
 
 #ifdef DBG_MEMORY_LEAK


### PR DESCRIPTION
## Summary
- use `kvmalloc` for `rtw_vmalloc`
- use `kvzalloc` for `rtw_zvmalloc`
- free memory via `kvfree`
- tidy spacing after including `<linux/mm.h>`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858327f7e90833198f4c414b70a113f