### PR TITLE
core: replace strncpy with strscpy

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -537,7 +537,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "ap_id:");
-				strncpy(p, tmp_str, len);
+                               memcpy(p, tmp_str, len);
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -545,7 +545,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->vap_id);
 				#endif
-				strncpy(p, tmp_str, len);
+                               memcpy(p, tmp_str, len);
 			}
 			#endif
 			#ifdef CONFIG_CLIENT_PORT_CFG
@@ -555,7 +555,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "c_pid:");
-				strncpy(p, tmp_str, len);
+                               memcpy(p, tmp_str, len);
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -563,7 +563,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->client_port);
 				#endif
-				strncpy(p, tmp_str, len);
+                               memcpy(p, tmp_str, len);
 			}
 			#endif
 
@@ -6969,11 +6969,11 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		if (_titlestring) {
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-				strncpy(p, str_val, len);
+                               memcpy(p, str_val, len);
 				p += len;
 			}
-			len = snprintf(str_val, sizeof(str_val), "%s", _titlestring);
-			strncpy(p, str_val, len);
+                       len = snprintf(str_val, sizeof(str_val), "%s", _titlestring);
+                       memcpy(p, str_val, len);
 			p += len;
 		}
 		if (p != &str_out[0]) {
@@ -6988,18 +6988,18 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 			p = &str_out[0];
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-				strncpy(p, str_val, len);
+                               memcpy(p, str_val, len);
 				p += len;
 			}
 			if (_idx_show) {
 				len = snprintf(str_val, sizeof(str_val), "0x%03X: ", __i * RTW_BUFDUMP_BSIZE);
-				strncpy(p, str_val, len);
+                               memcpy(p, str_val, len);
 				p += len;
 			}
 			for (__j =0; __j < RTW_BUFDUMP_BSIZE; __j++) {
 				idx = __i * RTW_BUFDUMP_BSIZE + __j;
 				len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__j + 1) % 4) == 0) ? "  " : " ");
-				strncpy(p, str_val, len);
+                               memcpy(p, str_val, len);
 				p += len;
 			}
 			_RTW_STR_DUMP_SEL(sel, str_out);
@@ -7009,18 +7009,18 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		p = &str_out[0];
 		if ((sel == RTW_DBGDUMP) && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-			strncpy(p, str_val, len);
+                       memcpy(p, str_val, len);
 			p += len;
 		}
 		if (_idx_show && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "0x%03X: ", block_num * RTW_BUFDUMP_BSIZE);
-			strncpy(p, str_val, len);
+                       memcpy(p, str_val, len);
 			p += len;
 		}
 		for (__i = 0; __i < remain_byte; __i++) {
 			idx = block_num * RTW_BUFDUMP_BSIZE + __i;
 			len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__i + 1) % 4) == 0) ? "  " : " ");
-			strncpy(p, str_val, len);
+                       memcpy(p, str_val, len);
 			p += len;
 		}
 		_RTW_STR_DUMP_SEL(sel, str_out);

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4359,7 +4359,7 @@ bool rtw_wowlan_parser_pattern_cmd(u8 *input, char *pattern,
 		} else {
 			u8 hex;
 
-			strncpy(member, input, len);
+                       memcpy(member, input, len);
 			if (!rtw_check_pattern_valid(member, sizeof(member))) {
 				RTW_INFO("%s:[ERROR] pattern is invalid!!\n",
 					 __func__);

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -12312,7 +12312,7 @@ ParseQualifiedString(
 		return _FALSE;
 
 	j = (*Start) - 2;
-	strncpy((char *)Out, (const char *)(In + i), j - i + 1);
+       memcpy(Out, In + i, j - i + 1);
 
 	return _TRUE;
 }

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -4858,9 +4858,9 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 				if (strlen(szLine) < 10 || szLine[0] != '[')
 					continue;
 
-				strncpy(band, szLine + 1, 2);
-				strncpy(path, szLine + 5, 1);
-				strncpy(sign, szLine + 8, 1);
+                               strscpy(band, szLine + 1, sizeof(band));
+                               strscpy(path, szLine + 5, sizeof(path));
+                               strscpy(sign, szLine + 8, sizeof(sign));
 
 				i = 10; /* szLine+10 */
 				if (!ParseQualifiedString(szLine, &i, rate, '[', ']')) {

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -4370,8 +4370,7 @@ void phydm_fw_trace_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		  "[FW debug message] freg_num = (( %d )), c2h_seq=(( %d ))\n",
 		  freg_num, c2h_seq);
 
-	strncpy(debug_trace_11byte, &cmd_buf[1], (cmd_len - 1));
-	debug_trace_11byte[cmd_len - 1] = '\0';
+       strscpy(debug_trace_11byte, &cmd_buf[1], sizeof(debug_trace_11byte));
 	PHYDM_DBG(dm, DBG_FW_TRACE, "[FW debug message] %s\n",
 		  debug_trace_11byte);
 	PHYDM_DBG(dm, DBG_FW_TRACE, "[FW debug message] cmd_len = (( %d ))\n",
@@ -4401,8 +4400,9 @@ void phydm_fw_trace_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		return;
 	}
 
-	strncpy((char *)&dm->fw_debug_trace[dm->c2h_cmd_start],
-		(char *)&cmd_buf[1], (cmd_len - 1));
+       strscpy(&dm->fw_debug_trace[dm->c2h_cmd_start],
+               &cmd_buf[1],
+               sizeof(dm->fw_debug_trace) - dm->c2h_cmd_start);
 	dm->c2h_cmd_start += (cmd_len - 1);
 	dm->fw_buff_is_enpty = false;
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1639,7 +1639,7 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 		goto addkey_end;
 	}
 
-	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+       strscpy(param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
 
 
 	if (!mac_addr || is_broadcast_ether_addr(mac_addr)
@@ -4395,8 +4395,7 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	}
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
-	strncpy(mon_ndev->name, name, IFNAMSIZ);
-	mon_ndev->name[IFNAMSIZ - 1] = 0;
+       strscpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->priv_destructor = rtw_ndev_destructor;
 
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -3130,7 +3130,7 @@ static int rtw_wx_set_enc_ext(struct net_device *dev,
 		goto exit;
 	}
 
-	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+       strscpy(param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
 
 	if (pext->ext_flags & IW_ENCODE_EXT_SET_TX_KEY)
 		param->u.crypt.set_tx = 1;
@@ -5817,8 +5817,7 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 #endif
 			reg_ifname = padapter->registrypriv.if2name;
 
-		strncpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
-		rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+               strscpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
 	}
 
 	/* RTW_INFO("%s wrqu->data.length:%d\n", __FUNCTION__, wrqu->data.length); */
@@ -5842,8 +5841,7 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 		/* rtw_ips_mode_req(&padapter->pwrctrlpriv, rereg_priv->old_ips_mode); */
 	}
 
-	strncpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
-	rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+       strscpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
 
 	if (_rtw_memcmp(new_ifname, "disable%d", 9) == _TRUE) {
 

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -1136,7 +1136,7 @@ int rtw_mp_psd(struct net_device *dev,
         }
 
         input[wrqu->length] = '\0';
-        strncpy(extra, (char *)input, wrqu->length + 1);
+       strscpy(extra, (char *)input, wrqu->length + 1);
 
         wrqu->length = mp_query_psd(padapter, extra);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1439,8 +1439,7 @@ int rtw_ndev_init(struct net_device *dev)
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d mac_addr="MAC_FMT"\n"
 		, FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1), MAC_ARG(dev->dev_addr));
-	strncpy(adapter->old_ifname, dev->name, IFNAMSIZ);
-	adapter->old_ifname[IFNAMSIZ - 1] = '\0';
+       strscpy(adapter->old_ifname, dev->name, IFNAMSIZ);
 	rtw_adapter_proc_init(dev);
 
 	return 0;

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1372,8 +1372,7 @@ static int rtw_cfgvendor_logger_start_logging(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
-					MIN(sizeof(ring_name) -1, nla_len(iter)));
+                               strscpy(ring_name, nla_data(iter), sizeof(ring_name));
 				break;
 			case LOGGER_ATTRIBUTE_LOG_LEVEL:
 				log_level = nla_get_u32(iter);
@@ -1501,8 +1500,7 @@ static int rtw_cfgvendor_logger_get_ring_data(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
-					MIN(sizeof(ring_name) -1, nla_len(iter)));
+                               strscpy(ring_name, nla_data(iter), sizeof(ring_name));
 				RTW_INFO(" %s LOGGER_ATTRIBUTE_RING_NAME : %s\n", __func__, ring_name);
 				break;
 			default:

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -748,7 +748,7 @@ static void process_spec_devid(const struct usb_device_id *pdid)
 		/* It is used to distinguish between normal and PC-side wifi dongle/module. */
 		if ((pdid->idVendor == vid) && (pdid->idProduct == pid) && (flags & SPEC_DEV_ID_ASSIGN_IFNAME)) {
 			extern char *ifname;
-			strncpy(ifname, "wlan10", 6);
+                       strscpy(ifname, "wlan10", IFNAMSIZ);
 			/* RTW_INFO("%s()-%d: ifname=%s, vid=%04X, pid=%04X\n", __FUNCTION__, __LINE__, ifname, vid, pid); */
 		}
 #endif /* RTK_DMP_PLATFORM */


### PR DESCRIPTION
## Summary
- replace deprecated `strncpy` calls with `strscpy`
- drop redundant manual terminators
- correct substring copies with `memcpy`

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858328961248331906d2d77d0035b3a