### PR TITLE
Use alloc_workqueue APIs

### DIFF
--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1543,7 +1543,7 @@ void rtw_btcoex_init_socket(_adapter *padapter)
 	RTW_INFO("%s\n", __func__);
 	if (_FALSE == pcoex_info->is_exist) {
 		_rtw_memset(pcoex_info, 0, sizeof(struct bt_coex_info));
-		pcoex_info->btcoex_wq = create_workqueue("BTCOEX");
+               pcoex_info->btcoex_wq = alloc_workqueue("BTCOEX", WQ_UNBOUND | WQ_MEM_RECLAIM, 1);
 		INIT_DELAYED_WORK(&pcoex_info->recvmsg_work,
 				  (void *)rtw_btcoex_recvmsgbysocket);
 		pbtcoexadapter = padapter;

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -2189,7 +2189,7 @@ void rtw_init_pwrctrl_priv(PADAPTER padapter)
 
 #ifdef CONFIG_RESUME_IN_WORKQUEUE
 	_init_workitem(&pwrctrlpriv->resume_work, resume_workitem_callback, NULL);
-	pwrctrlpriv->rtw_workqueue = create_singlethread_workqueue("rtw_workqueue");
+       pwrctrlpriv->rtw_workqueue = alloc_workqueue("rtw_workqueue", WQ_UNBOUND | WQ_MEM_RECLAIM, 1);
 #endif /* CONFIG_RESUME_IN_WORKQUEUE */
 
 #if defined(CONFIG_HAS_EARLYSUSPEND) || defined(CONFIG_ANDROID_POWER)


### PR DESCRIPTION
## Summary
- use `alloc_workqueue` for rtw power control
- use `alloc_workqueue` for btcoex

## Testing
- `./tests/test_kernel_5.4.sh`


------
https://chatgpt.com/codex/tasks/task_e_6858329360448331b3437489a8befec4