### PR TITLE
Remove daemonize call from loopback thread

### DIFF
--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -11864,8 +11864,7 @@ thread_return lbk_thread(thread_context context)
 	ok = 0;
 	fail = 0;
 
-	daemonize("%s", "RTW_LBK_THREAD");
-	allow_signal(SIGTERM);
+       allow_signal(SIGTERM);
 
 	do {
 		if (ploopback->size == 0) {


### PR DESCRIPTION
## Summary
- drop obsolete daemonize call in lbk_thread

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68586c96a1508331a4d0186a74e313b7