### PR TITLE
core: use etherdevice helpers

### DIFF
--- a/core/mesh/rtw_mesh.c
+++ b/core/mesh/rtw_mesh.c
@@ -16,6 +16,7 @@
 
 #ifdef CONFIG_RTW_MESH
 #include <drv_types.h>
+#include <linux/etherdevice.h>
 
 const char *_rtw_mesh_plink_str[] = {
 	"UNKNOWN",
@@ -3284,8 +3285,8 @@ static bool rtw_mesh_data_bmc_to_uc(_adapter *adapter
 		if (!(sta->state & _FW_LINKED)
 			|| _rtw_memcmp(sta->cmn.mac_addr, msa, ETH_ALEN) == _TRUE
 			|| (ori_ta && _rtw_memcmp(sta->cmn.mac_addr, ori_ta, ETH_ALEN) == _TRUE)
-			|| is_broadcast_mac_addr(sta->cmn.mac_addr)
-			|| is_zero_mac_addr(sta->cmn.mac_addr))
+			|| is_broadcast_ether_addr(sta->cmn.mac_addr)
+			|| is_zero_ether_addr(sta->cmn.mac_addr))
 			continue;
 
 		b2uframe = rtw_alloc_xmitframe(xmitpriv);

--- a/core/mesh/rtw_mesh.h
+++ b/core/mesh/rtw_mesh.h
@@ -15,6 +15,8 @@
 #ifndef __RTW_MESH_H_
 #define __RTW_MESH_H_
 
+#include <linux/etherdevice.h>
+
 #ifndef CONFIG_AP_MODE
 	#error "CONFIG_RTW_MESH can't be enabled when CONFIG_AP_MODE is not defined\n"
 #endif
@@ -287,14 +289,14 @@ struct mesh_peer_sel_policy {
 
 #define rtw_msrc_b2u_policy_chk(flags, mda) ( \
 	(flags & RTW_MESH_B2U_ALL) \
-	|| ((flags & RTW_MESH_B2U_BCAST) && is_broadcast_mac_addr(mda)) \
+	|| ((flags & RTW_MESH_B2U_BCAST) && is_broadcast_ether_addr(mda)) \
 	|| ((flags & RTW_MESH_B2U_IP_MCAST) && (IP_MCAST_MAC(mda) || ICMPV6_MCAST_MAC(mda))) \
 	)
 
 #define rtw_mfwd_b2u_policy_chk(flags, mda, ucst) ( \
 	(flags & RTW_MESH_B2U_ALL) \
 	|| ((flags & RTW_MESH_B2U_GA_UCAST) && ucst) \
-	|| ((flags & RTW_MESH_B2U_BCAST) && is_broadcast_mac_addr(mda)) \
+	|| ((flags & RTW_MESH_B2U_BCAST) && is_broadcast_ether_addr(mda)) \
 	|| ((flags & RTW_MESH_B2U_IP_MCAST) && (IP_MCAST_MAC(mda) || ICMPV6_MCAST_MAC(mda))) \
 	)
 

--- a/core/mesh/rtw_mesh_pathtbl.c
+++ b/core/mesh/rtw_mesh_pathtbl.c
@@ -17,6 +17,7 @@
 #ifdef CONFIG_RTW_MESH
 #include <drv_types.h>
 #include <linux/jhash.h>
+#include <linux/etherdevice.h>
 
 static void rtw_mpath_free_rcu(struct rtw_mesh_path *mpath)
 {
@@ -564,7 +565,7 @@ struct rtw_mesh_path *rtw_mesh_path_add(_adapter *adapter,
 		/* never add ourselves as neighbours */
 		return ERR_PTR(-ENOTSUPP);
 
-	if (is_multicast_mac_addr(dst))
+	if (is_multicast_ether_addr(dst))
 		return ERR_PTR(-ENOTSUPP);
 
 	if (ATOMIC_INC_UNLESS(&adapter->mesh_info.mpaths, RTW_MESH_MAX_MPATHS) == 0)
@@ -615,7 +616,7 @@ int rtw_mpp_path_add(_adapter *adapter,
 		/* never add ourselves as neighbours */
 		return -ENOTSUPP;
 
-	if (is_multicast_mac_addr(dst))
+	if (is_multicast_ether_addr(dst))
 		return -ENOTSUPP;
 
 	new_mpath = rtw_mesh_path_new(adapter, dst);

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 #ifdef CONFIG_AP_MODE
 
@@ -2674,7 +2675,7 @@ int rtw_acl_remove_sta(_adapter *adapter, u8 period, const u8 *addr)
 	struct sta_priv *stapriv = &adapter->stapriv;
 	struct wlan_acl_pool *acl;
 	_queue	*acl_node_q;
-	u8 is_baddr = is_broadcast_mac_addr(addr);
+	u8 is_baddr = is_broadcast_ether_addr(addr);
 	u8 match = 0;
 
 	if (period >= RTW_ACL_PERIOD_NUM) {

--- a/core/rtw_ioctl_set.c
+++ b/core/rtw_ioctl_set.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 
 extern void indicate_wx_scan_complete_event(_adapter *padapter);
@@ -31,9 +32,9 @@ u8 rtw_validate_bssid(u8 *bssid)
 {
 	u8 ret = _TRUE;
 
-	if (is_zero_mac_addr(bssid)
-	    || is_broadcast_mac_addr(bssid)
-	    || is_multicast_mac_addr(bssid)
+	if (is_zero_ether_addr(bssid)
+	    || is_broadcast_ether_addr(bssid)
+	    || is_multicast_ether_addr(bssid)
 	   )
 		ret = _FALSE;
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -15,6 +15,7 @@
 #define _RTW_MLME_C_
 
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 extern void indicate_wx_scan_complete_event(_adapter *padapter);
 extern u8 rtw_do_join(_adapter *padapter);
@@ -3377,7 +3378,7 @@ static void collect_sta_traffic_statistics(_adapter *adapter)
 
 	for (i = 0; i < MACID_NUM_SW_LIMIT; i++) {
 		sta = macid_ctl->sta[i];
-		if (sta && !is_broadcast_mac_addr(sta->cmn.mac_addr)) {
+		if (sta && !is_broadcast_ether_addr(sta->cmn.mac_addr)) {
 			if (sta->sta_stats.last_tx_bytes > sta->sta_stats.tx_bytes)
 				sta->sta_stats.last_tx_bytes =  sta->sta_stats.tx_bytes;
 			if (sta->sta_stats.last_rx_bytes > sta->sta_stats.rx_bytes)
@@ -3425,7 +3426,7 @@ void rtw_sta_traffic_info(void *sel, _adapter *adapter)
 
 	for (i = 0; i < MACID_NUM_SW_LIMIT; i++) {
 		sta = macid_ctl->sta[i];
-		if (sta && !is_broadcast_mac_addr(sta->cmn.mac_addr))
+		if (sta && !is_broadcast_ether_addr(sta->cmn.mac_addr))
 			dump_sta_traffic(sel, adapter, sta);
 	}
 }
@@ -3598,7 +3599,7 @@ static int rtw_check_roaming_candidate(struct mlme_priv *mlme
 		);
 
 	/* got specific addr to roam */
-	if (!is_zero_mac_addr(mlme->roam_tgt_addr)) {
+	if (!is_zero_ether_addr(mlme->roam_tgt_addr)) {
 		if (_rtw_memcmp(mlme->roam_tgt_addr, competitor->network.MacAddress, ETH_ALEN) == _TRUE)
 			goto update;
 		else

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -15,6 +15,7 @@
 #define _RTW_MLME_EXT_C_
 
 #include <drv_types.h>
+#include <linux/etherdevice.h>
 #ifdef CONFIG_IOCTL_CFG80211
 	#include <rtw_wifi_regd.h>
 #endif /* CONFIG_IOCTL_CFG80211 */
@@ -6924,7 +6925,7 @@ unsigned int OnAction_ft(_adapter *padapter, union recv_frame *precv_frame)
 			goto exit;
 		}
 
-		if (is_zero_mac_addr(&pframe_body[8]) || is_broadcast_mac_addr(&pframe_body[8])) {
+		if (is_zero_ether_addr(&pframe_body[8]) || is_broadcast_ether_addr(&pframe_body[8])) {
 			RTW_ERR("FT: Invalid Target MAC Address "MAC_FMT"\n", MAC_ARG(padapter->mlmepriv.roam_tgt_addr));
 			goto exit;
 		}
@@ -7176,7 +7177,7 @@ void rtw_wnm_issue_action(_adapter *padapter, u8 action, u8 reason)
 			pframe = rtw_set_fixed_ie(pframe, 1, &(dialog_token), &(pattrib->pktlen));
 			pframe = rtw_set_fixed_ie(pframe, 1, &(reason), &(pattrib->pktlen));
 			pframe = rtw_set_fixed_ie(pframe, 1, &(termination_delay), &(pattrib->pktlen));
-			if (!is_zero_mac_addr(pmlmepriv->nb_info.roam_target_addr)) {
+			if (!is_zero_ether_addr(pmlmepriv->nb_info.roam_target_addr)) {
 				pframe = rtw_set_fixed_ie(pframe, 6, 
 					pmlmepriv->nb_info.roam_target_addr, &(pattrib->pktlen));
 			}
@@ -12979,7 +12980,7 @@ bypass_active_keep_alive:
 				psta = LIST_CONTAINOR(plist, struct sta_info, hash_list);
 				plist = get_next(plist);
 
-				if (is_broadcast_mac_addr(psta->cmn.mac_addr))
+				if (is_broadcast_ether_addr(psta->cmn.mac_addr))
 					continue;
 
 				if (chk_adhoc_peer_is_alive(psta) || !psta->expire_to)

--- a/core/rtw_odm.c
+++ b/core/rtw_odm.c
@@ -15,6 +15,7 @@
 
 #include <rtw_odm.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 u32 rtw_phydm_ability_ops(_adapter *adapter, HAL_PHYDM_OPS ops, u32 ability)
 {
@@ -273,7 +274,7 @@ void rtw_odm_parse_rx_phy_status_chinfo(union recv_frame *rframe, u8 *phys)
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u)\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_ether_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_ether_addr(get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t0->band, phys_t0->channel, phys_t0->rxsc
 				);
@@ -389,7 +390,7 @@ type1_end:
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, rf_mode:%u, l_rxsc:%u, ht_rxsc:%u) => %u,%u\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_ether_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_ether_addr(get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t1->band, phys_t1->channel, phys_t1->rf_mode, phys_t1->l_rxsc, phys_t1->ht_rxsc
 					, pkt_cch, pkt_bw
@@ -407,7 +408,7 @@ type1_end:
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u, ht_rxsc:%u)\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_ether_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_ether_addr(get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t2->band, phys_t2->channel, phys_t2->l_rxsc, phys_t2->ht_rxsc
 				);

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -15,6 +15,7 @@
 #define _RTW_RECV_C_
 
 #include <drv_types.h>
+#include <linux/etherdevice.h>
 #include <hal_data.h>
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS
@@ -1135,7 +1136,7 @@ void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_in
 		pstats->last_rx_time = rtw_get_current_time();
 		pstats->rx_data_pkts++;
 		pstats->rx_bytes += sz;
-		if (is_broadcast_mac_addr(pattrib->ra)) {
+		if (is_broadcast_ether_addr(pattrib->ra)) {
 			pstats->rx_data_bc_pkts++;
 			pstats->rx_bc_bytes += sz;
 		} else if (is_ra_bmc) {
@@ -1987,8 +1988,8 @@ sint validate_recv_mgnt_frame(PADAPTER padapter, union recv_frame *precv_frame)
 		else if (get_frame_sub_type(precv_frame->u.hdr.rx_data) == WIFI_PROBERSP) {
 			if (_rtw_memcmp(adapter_mac_addr(padapter), GetAddr1Ptr(precv_frame->u.hdr.rx_data), ETH_ALEN) == _TRUE)
 				psta->sta_stats.rx_probersp_pkts++;
-			else if (is_broadcast_mac_addr(GetAddr1Ptr(precv_frame->u.hdr.rx_data))
-				|| is_multicast_mac_addr(GetAddr1Ptr(precv_frame->u.hdr.rx_data)))
+			else if (is_broadcast_ether_addr(GetAddr1Ptr(precv_frame->u.hdr.rx_data))
+				|| is_multicast_ether_addr(GetAddr1Ptr(precv_frame->u.hdr.rx_data)))
 				psta->sta_stats.rx_probersp_bm_pkts++;
 			else
 				psta->sta_stats.rx_probersp_uo_pkts++;

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -15,6 +15,7 @@
 #define  _RTW_SECURITY_C_
 
 #include <drv_types.h>
+#include <linux/etherdevice.h>
 
 static const char *_security_type_str[] = {
 	"N/A",
@@ -41,54 +42,54 @@ const char *security_type_str(u8 value)
 
 #ifdef DBG_SW_SEC_CNT
 #define WEP_SW_ENC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->wep_sw_enc_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->wep_sw_enc_cnt_mc++; \
 	else \
 		sec->wep_sw_enc_cnt_uc++; \
 	} while (0)
 
 #define WEP_SW_DEC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->wep_sw_dec_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->wep_sw_dec_cnt_mc++; \
 	else \
 		sec->wep_sw_dec_cnt_uc++; \
 	} while (0)
 
 #define TKIP_SW_ENC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->tkip_sw_enc_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->tkip_sw_enc_cnt_mc++; \
 	else \
 		sec->tkip_sw_enc_cnt_uc++; \
 	} while (0)
 
 #define TKIP_SW_DEC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->tkip_sw_dec_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->tkip_sw_dec_cnt_mc++; \
 	else \
 		sec->tkip_sw_dec_cnt_uc++; \
 	} while (0)
 
 #define AES_SW_ENC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->aes_sw_enc_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->aes_sw_enc_cnt_mc++; \
 	else \
 		sec->aes_sw_enc_cnt_uc++; \
 	} while (0)
 
 #define AES_SW_DEC_CNT_INC(sec, ra) do {\
-	if (is_broadcast_mac_addr(ra)) \
+	if (is_broadcast_ether_addr(ra)) \
 		sec->aes_sw_dec_cnt_bc++; \
-	else if (is_multicast_mac_addr(ra)) \
+	else if (is_multicast_ether_addr(ra)) \
 		sec->aes_sw_dec_cnt_mc++; \
 	else \
 		sec->aes_sw_dec_cnt_uc++; \
@@ -831,7 +832,7 @@ u32 rtw_tkip_decrypt(_adapter *padapter, u8 *precvframe)
 					if (start == 0)
 						start = rtw_get_current_time();
 
-					if (is_broadcast_mac_addr(prxattrib->ra))
+					if (is_broadcast_ether_addr(prxattrib->ra))
 						no_gkey_bc_cnt++;
 					else
 						no_gkey_mc_cnt++;
@@ -1952,7 +1953,7 @@ u32	rtw_aes_decrypt(_adapter *padapter, u8 *precvframe)
 					if (start == 0)
 						start = rtw_get_current_time();
 
-					if (is_broadcast_mac_addr(prxattrib->ra))
+					if (is_broadcast_ether_addr(prxattrib->ra))
 						no_gkey_bc_cnt++;
 					else
 						no_gkey_mc_cnt++;

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 static u8 P802_1H_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0xf8 };
 static u8 RFC1042_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0x00 };
@@ -4449,7 +4450,7 @@ s32 rtw_monitor_xmit_entry(struct sk_buff *skb, struct net_device *ndev)
 		pattrib = &pmgntframe->attrib;
 		update_monitor_frame_attrib(padapter, pattrib);
 
-		if (is_broadcast_mac_addr(pwlanhdr->addr3) || is_broadcast_mac_addr(pwlanhdr->addr1))
+		if (is_broadcast_ether_addr(pwlanhdr->addr3) || is_broadcast_ether_addr(pwlanhdr->addr1))
 			pattrib->rate = MGN_24M;
 
 	} else {
@@ -4835,7 +4836,7 @@ sint xmitframe_enqueue_for_sleeping_sta(_adapter *padapter, struct xmit_frame *p
 			/* RTW_INFO("enqueue, sq_len=%d\n", psta->sleepq_len); */
 			/* RTW_INFO_DUMP("enqueue, tim=", pstapriv->tim_bitmap, pstapriv->aid_bmp_len); */
 			if (update_tim == _TRUE) {
-				if (is_broadcast_mac_addr(pattrib->ra))
+				if (is_broadcast_ether_addr(pattrib->ra))
 					_update_beacon(padapter, _TIM_IE_, NULL, _TRUE, "buffer BC");
 				else
 					_update_beacon(padapter, _TIM_IE_, NULL, _TRUE, "buffer MC");

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -18,6 +18,7 @@
 #include "hal_com_h2c.h"
 
 #include "hal_data.h"
+#include <linux/etherdevice.h>
 
 #ifdef RTW_HALMAC
 #include "../../hal/hal_halmac.h"
@@ -7861,7 +7862,7 @@ static void rtw_hal_construct_ARPRsp(
 	SET_ARP_SENDER_MAC_ADDR(pARPRspPkt, adapter_mac_addr(padapter));
 	SET_ARP_SENDER_IP_ADDR(pARPRspPkt, pIPAddress);
 #ifdef CONFIG_ARP_KEEP_ALIVE
-	if (!is_zero_mac_addr(pmlmepriv->gw_mac_addr)) {
+	if (!is_zero_ether_addr(pmlmepriv->gw_mac_addr)) {
 		SET_ARP_TARGET_MAC_ADDR(pARPRspPkt, pmlmepriv->gw_mac_addr);
 		SET_ARP_TARGET_IP_ADDR(pARPRspPkt, pmlmepriv->gw_ip);
 	} else

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -15,6 +15,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 /* A mapping from HalData to ODM. */
 enum odm_board_type boardType(u8 InterfaceSel)
@@ -759,7 +760,7 @@ s8 rtw_dm_get_min_rssi(_adapter *adapter)
 	for (i = 0; i < MACID_NUM_SW_LIMIT; i++) {
 		sta = macid_ctl->sta[i];
 		if (!sta || !GET_H2CCMD_MSRRPT_PARM_OPMODE(macid_ctl->h2c_msr + i)
-			|| is_broadcast_mac_addr(sta->cmn.mac_addr))
+			|| is_broadcast_ether_addr(sta->cmn.mac_addr))
 			continue;
 		rssi = sta->cmn.rssi_stat.rssi;
 		if (rssi >= 0 && min_rssi > rssi)

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1458,22 +1458,6 @@ enum ieee80211_state {
 #define PORT_FMT "%u"
 #define PORT_ARG(x) ntohs(*((u16 *)(x)))
 
-extern __inline int is_multicast_mac_addr(const u8 *addr)
-{
-        return (addr[0] != 0xff) && (0x01 & addr[0]);
-}
-
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
-		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
-}
-
-extern __inline int is_zero_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
-		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
-}
 
 #define CFG_IEEE80211_RESERVE_FCS (1<<0)
 #define CFG_IEEE80211_COMPUTE_FCS (1<<1)

--- a/include/rtw_mlme.h
+++ b/include/rtw_mlme.h
@@ -15,6 +15,8 @@
 #ifndef __RTW_MLME_H_
 #define __RTW_MLME_H_
 
+#include <linux/etherdevice.h>
+
 
 #define	MAX_BSS_CNT	128
 /* #define   MAX_JOIN_TIMEOUT	2000 */
@@ -662,13 +664,13 @@ struct ft_roam_info {
 
 #define rtw_wnm_btm_diff_bss(a) \
 	((rtw_wnm_btm_preference_cap(a)) && \
-	(is_zero_mac_addr((a)->mlmepriv.nb_info.roam_target_addr) == _FALSE) && \
+	(is_zero_ether_addr((a)->mlmepriv.nb_info.roam_target_addr) == _FALSE) && \
 	(_rtw_memcmp((a)->mlmepriv.nb_info.roam_target_addr,\
 		(a)->mlmepriv.cur_network.network.MacAddress, ETH_ALEN) == _FALSE))
 
 #define rtw_wnm_btm_roam_candidate(a, c) \
 	((rtw_wnm_btm_preference_cap(a)) && \
-	(is_zero_mac_addr((a)->mlmepriv.nb_info.roam_target_addr) == _FALSE) && \
+	(is_zero_ether_addr((a)->mlmepriv.nb_info.roam_target_addr) == _FALSE) && \
 	(_rtw_memcmp((a)->mlmepriv.nb_info.roam_target_addr,\
 		(c)->network.MacAddress, ETH_ALEN)))
 
@@ -698,7 +700,7 @@ struct nb_rpt_hdr {
 	u8 phy_type;	
 };
 
-/*IEEE Std 80211v, Figure 7-95e2¡XBSS Termination Duration subelement field format */
+/*IEEE Std 80211v, Figure 7-95e2Â¡XBSS Termination Duration subelement field format */
 struct btm_term_duration {
 	u8 id;
 	u8 len;
@@ -706,7 +708,7 @@ struct btm_term_duration {
 	u16 duration;
 };
 
-/*IEEE Std 80211v, Figure 7-101n8¡XBSS Transition Management Request frame body format */
+/*IEEE Std 80211v, Figure 7-101n8Â¡XBSS Transition Management Request frame body format */
 struct btm_req_hdr {
 	u8 req_mode;
 	u16 disassoc_timer;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -17,6 +17,7 @@
 #include <linux/ktime.h>
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
 #error "Kernel versions below 5.4 are not supported"
@@ -1140,7 +1141,7 @@ static int rtw_cfg80211_ap_set_encryption(struct net_device *dev, struct ieee_pa
 	param->u.crypt.err = 0;
 	param->u.crypt.alg[IEEE_CRYPT_ALG_NAME_LEN - 1] = '\0';
 
-	if (is_broadcast_mac_addr(param->sta_addr)) {
+	if (is_broadcast_ether_addr(param->sta_addr)) {
 		if (param->u.crypt.idx >= WEP_KEYS
 			#ifdef CONFIG_IEEE80211W
 			&& param->u.crypt.idx > BIP_MAX_KEYID
@@ -1394,7 +1395,7 @@ static int rtw_cfg80211_set_encryption(struct net_device *dev, struct ieee_param
 	param->u.crypt.err = 0;
 	param->u.crypt.alg[IEEE_CRYPT_ALG_NAME_LEN - 1] = '\0';
 
-	if (is_broadcast_mac_addr(param->sta_addr)) {
+	if (is_broadcast_ether_addr(param->sta_addr)) {
 		if (param->u.crypt.idx >= WEP_KEYS
 			#ifdef CONFIG_IEEE80211W
 			&& param->u.crypt.idx > BIP_MAX_KEYID

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -16,6 +16,7 @@
 #include <linux/ctype.h>	/* tolower() */
 #include <drv_types.h>
 #include <hal_data.h>
+#include <linux/etherdevice.h>
 #include "rtw_proc.h"
 #include <rtw_btcoex.h>
 
@@ -1326,7 +1327,7 @@ ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_
 			if (sscanf(c, MAC_SFMT, MAC_SARG(addr)) != 6)
 				break;
 
-			is_bcast = is_broadcast_mac_addr(addr);
+			is_bcast = is_broadcast_ether_addr(addr);
 			if (is_bcast
 				|| rtw_check_invalid_mac_address(addr, 0) == _FALSE
 			) {
@@ -2011,7 +2012,7 @@ static void rtw_set_tx_bw_mode(struct _ADAPTER *adapter, u8 bw_mode)
 
 		for (i = 0; i < MACID_NUM_SW_LIMIT; i++) {
 			sta = macid_ctl->sta[i];
-			if (sta && !is_broadcast_mac_addr(sta->cmn.mac_addr))
+			if (sta && !is_broadcast_ether_addr(sta->cmn.mac_addr))
 				rtw_dm_ra_mask_wk_cmd(adapter, (u8 *)sta);
 		}
 	}

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -15,6 +15,7 @@
 #define _XMIT_OSDEP_C_
 
 #include <drv_types.h>
+#include <linux/etherdevice.h>
 
 #define DBG_DUMP_OS_QUEUE_CTL 0
 
@@ -436,7 +437,7 @@ int _rtw_xmit_entry(_pkt *pkt, _nic_hdl pnetdev)
 		&& (IP_MCAST_MAC(pkt->data)
 			|| ICMPV6_MCAST_MAC(pkt->data)
 			#ifdef CONFIG_TX_BCAST2UNI
-			|| is_broadcast_mac_addr(pkt->data)
+			|| is_broadcast_ether_addr(pkt->data)
 			#endif
 			)
 		&& (padapter->registrypriv.wifi_spec == 0)


### PR DESCRIPTION
## Summary
- remove custom MAC address helpers
- use etherdevice.h helpers throughout the driver
- include `<linux/etherdevice.h>` where required
- build and run kernel 5.4 test

## Testing
- `./tests/test_kernel_5.4.sh`

------
https://chatgpt.com/codex/tasks/task_e_68586cde969c833182923491191ab011